### PR TITLE
fix: grpc microservice에서 app 설정 상속하도록 수정

### DIFF
--- a/src/shared/core/presentations/Config.ts
+++ b/src/shared/core/presentations/Config.ts
@@ -56,7 +56,7 @@ export async function createMicroservices(
   config: GrpcServiceConfig,
 ): Promise<INestApplication> {
   const app = await NestFactory.create(module);
-  app.connectMicroservice(createGrpcOptions(serviceName, config));
+  app.connectMicroservice(createGrpcOptions(serviceName, config), { inheritAppConfig: true });
   app.connectMicroservice({
     transport: Transport.KAFKA,
     options: {


### PR DESCRIPTION
서비스 실행로직이 바뀌고 logging interceptor가 동작하지 않는 것 같아서 마이크로서비스 연결할 때 app의 전역설정들 상속하도록 옵션 추가하였습니다