### PR TITLE
fix: 상담 생성, 메시지 생성 이벤트에 id값 정상적으로 포함되도록 수정

### DIFF
--- a/src/aggregates/counselMessages/domain/CounselMessages.ts
+++ b/src/aggregates/counselMessages/domain/CounselMessages.ts
@@ -11,12 +11,9 @@ import { CounselMessageCreatedPayloadSchema } from "~/src/gen/com/hearlers/v1/me
 
 interface CounselMessagesNewProps {
   counselId: UniqueEntityId;
+  userId: number;
   message: string;
   isUserMessage: boolean;
-}
-
-interface CounselMessagesNewPropsForEvent extends CounselMessagesNewProps {
-  userId: number;
 }
 
 interface CounselMessagesProps extends CounselMessagesNewProps {
@@ -41,13 +38,12 @@ export class CounselMessages extends AggregateRoot<CounselMessagesProps> {
     return Result.ok<CounselMessages>(counselMessages);
   }
 
-  public static createNew(newProps: CounselMessagesNewPropsForEvent): Result<CounselMessages> {
+  public static createNew(newProps: CounselMessagesNewProps): Result<CounselMessages> {
     const now = getNowDayjs();
     const newId = new UniqueEntityId();
-    const { userId, ...newPropsWithoutUserId } = newProps;
     const createdMessage = this.create(
       {
-        ...newPropsWithoutUserId,
+        ...newProps,
         reactedAt: null,
         reaction: null,
         createdAt: now,
@@ -56,17 +52,6 @@ export class CounselMessages extends AggregateRoot<CounselMessagesProps> {
       },
       newId,
     );
-    if (createdMessage.isSuccess) {
-      const message = createdMessage.value;
-      const counselMessageCreated = create(CounselMessageCreatedPayloadSchema, {
-        counselId: message.counselId.getNumber(),
-        userId: userId,
-        message: message.message,
-        isUserMessage: message.isUserMessage,
-        occurredAt: formatDayjs(now),
-      });
-      createdMessage.value.addDomainEvent(new CounselMessageCreatedEvent(counselMessageCreated));
-    }
 
     return createdMessage;
   }
@@ -75,6 +60,11 @@ export class CounselMessages extends AggregateRoot<CounselMessagesProps> {
     // counselId 검증
     if (this.props.counselId === null || this.props.counselId === undefined) {
       return Result.fail<void>("[CounselMessages] 상담 ID는 필수입니다");
+    }
+
+    // userId 검증
+    if (this.props.userId === null || this.props.userId === undefined) {
+      return Result.fail<void>("[CounselMessages] 사용자 ID는 필수입니다");
     }
 
     // message 검증
@@ -105,6 +95,10 @@ export class CounselMessages extends AggregateRoot<CounselMessagesProps> {
   // Getters
   get counselId(): UniqueEntityId {
     return this.props.counselId;
+  }
+
+  get userId(): number {
+    return this.props.userId;
   }
 
   get message(): string {
@@ -172,5 +166,17 @@ export class CounselMessages extends AggregateRoot<CounselMessagesProps> {
 
     this.props.updatedAt = getNowDayjs();
     return Result.ok<void>();
+  }
+
+  public addCreatedEvent(): void {
+    const counselMessageCreated = create(CounselMessageCreatedPayloadSchema, {
+      counselMessageId: this.id.getNumber(),
+      counselId: this.counselId.getNumber(),
+      userId: this.userId,
+      message: this.message,
+      isUserMessage: this.isUserMessage,
+      occurredAt: formatDayjs(getNowDayjs()),
+    });
+    this.addDomainEvent(new CounselMessageCreatedEvent(counselMessageCreated));
   }
 }

--- a/src/aggregates/counselMessages/infrastructures/adaptors/mapper/psql.counselMessages.mapper.ts
+++ b/src/aggregates/counselMessages/infrastructures/adaptors/mapper/psql.counselMessages.mapper.ts
@@ -14,6 +14,7 @@ export class PsqlCounselMessagesMapper {
     const counselMessageProps = {
       counselId: new UniqueEntityId(entity.counselId),
       message: entity.message,
+      userId: entity.userId,
       isUserMessage: entity.isUserMessage,
       reactedAt: entity.reactedAt ? convertDayjs(entity.reactedAt) : null,
       reaction: entity.reaction ? entity.reaction : null,
@@ -39,6 +40,8 @@ export class PsqlCounselMessagesMapper {
     if (!counselMessages.counselId.isNewIdentifier()) {
       entity.counselId = counselMessages.counselId.getNumber();
     }
+
+    entity.userId = counselMessages.userId;
 
     entity.message = counselMessages.message;
     entity.isUserMessage = counselMessages.isUserMessage;

--- a/src/aggregates/counselMessages/infrastructures/adaptors/psql.counselMessages.repository.adaptor.ts
+++ b/src/aggregates/counselMessages/infrastructures/adaptors/psql.counselMessages.repository.adaptor.ts
@@ -28,11 +28,14 @@ export class PsqlCounselMessagesRepositoryAdaptor implements CounselMessagesRepo
 
   async create(counselMessage: CounselMessages): Promise<CounselMessages> {
     const counselMessagesEntity = PsqlCounselMessagesMapper.toEntity(counselMessage);
-    const createdCounselsEntity = await this.counselMessagesRepository.save(counselMessagesEntity);
+    const createdCounselMessagesEntity = await this.counselMessagesRepository.save(counselMessagesEntity);
+    const createdCounselMessage = PsqlCounselMessagesMapper.toDomain(createdCounselMessagesEntity);
+    createdCounselMessage.addCreatedEvent();
 
     await this.publishDomainEvents(counselMessage);
+    await this.publishDomainEvents(createdCounselMessage);
 
-    return PsqlCounselMessagesMapper.toDomain(createdCounselsEntity);
+    return createdCounselMessage;
   }
 
   async findMany(props: FindManyPropsInCounselMessagesRepository): Promise<CounselMessages[]> {

--- a/src/aggregates/counsels/domain/Counsels.ts
+++ b/src/aggregates/counsels/domain/Counsels.ts
@@ -52,16 +52,6 @@ export class Counsels extends AggregateRoot<CounselsProps> {
       },
       newId,
     );
-    if (createdCounsel.isSuccess) {
-      const counsel = createdCounsel.value;
-      const counselCreated = create(CounselCreatedPayloadSchema, {
-        counselId: counsel.id.getNumber(),
-        userId: counsel.userId,
-        counselorId: counsel.counselorId,
-        occurredAt: formatDayjs(getNowDayjs()),
-      });
-      createdCounsel.value.addDomainEvent(new CounselCreatedEvent(counselCreated));
-    }
 
     return createdCounsel;
   }
@@ -152,6 +142,16 @@ export class Counsels extends AggregateRoot<CounselsProps> {
     }
     const now = getNowDayjs();
     return now.isAfter(lastChatedAt.add(6, "hour"));
+  }
+
+  public addCreatedEvent(): void {
+    const counselCreated = create(CounselCreatedPayloadSchema, {
+      counselId: this.id.getNumber(),
+      userId: this.userId,
+      counselorId: this.counselorId,
+      occurredAt: formatDayjs(getNowDayjs()),
+    });
+    this.addDomainEvent(new CounselCreatedEvent(counselCreated));
   }
 
   public delete(): void {

--- a/src/aggregates/counsels/infrastructures/adaptors/psql.counsels.repository.adaptor.ts
+++ b/src/aggregates/counsels/infrastructures/adaptors/psql.counsels.repository.adaptor.ts
@@ -25,10 +25,13 @@ export class PsqlCounselsRepositoryAdaptor implements CounselsRepositoryPort {
   async create(counsel: Counsels): Promise<Counsels> {
     const counselsEntity = PsqlCounselsMapper.toEntity(counsel);
     const createdCounselsEntity = await this.counselsRepository.save(counselsEntity);
+    const createdCounsel = PsqlCounselsMapper.toDomain(createdCounselsEntity);
+    createdCounsel.addCreatedEvent();
 
     await this.publishDomainEvents(counsel);
+    await this.publishDomainEvents(createdCounsel);
 
-    return PsqlCounselsMapper.toDomain(createdCounselsEntity);
+    return createdCounsel;
   }
 
   async findMany(props: FindManyPropsInCounselsRepository): Promise<Counsels[] | null> {

--- a/src/shared/core/infrastructure/entities/CounselMessages.entity.ts
+++ b/src/shared/core/infrastructure/entities/CounselMessages.entity.ts
@@ -23,6 +23,13 @@ export class CounselMessagesEntity extends CoreEntity {
   counselId: number;
 
   @Column({
+    type: "int",
+    name: "user_id",
+    comment: "사용자 ID",
+  })
+  userId: number;
+
+  @Column({
     type: "varchar",
     name: "message",
     comment: "메시지 내용",


### PR DESCRIPTION
- counselMessage 엔티티에 userId 포함