### PR TITLE
fix: counseling bc 매퍼 로직 안정화

### DIFF
--- a/src/services/counselings/infrastructures/counselMessages/mappers/psql.counselMessages.mapper.ts
+++ b/src/services/counselings/infrastructures/counselMessages/mappers/psql.counselMessages.mapper.ts
@@ -1,13 +1,21 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { CounselMessagesEntity } from "~shared/core/infrastructure/entities/counsels/CounselMessages.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { CounselMessages, CounselMessagesProps } from "~counselings/domains/counselMessages/models/counselMessages";
+import {
+  CounselMessages,
+  CounselMessagesProps,
+} from "~counselings/domains/counselMessages/models/counselMessages";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlCounselMessagesMapper {
-  static toDomain(entity: CounselMessagesEntity): CounselMessages | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: CounselMessagesEntity): CounselMessages;
+  static toDomain(entity: CounselMessagesEntity | null): CounselMessages | null;
+  static toDomain(
+    entity: CounselMessagesEntity | null
+  ): CounselMessages | null {
     if (!entity) {
       return null;
     }
@@ -26,20 +34,23 @@ export class PsqlCounselMessagesMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const counselMessagesOrError = CounselMessages.create(counselMessageProps, new UniqueEntityId(entity.id));
+    const counselMessagesOrError = CounselMessages.create(
+      counselMessageProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (counselMessagesOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, counselMessagesOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        counselMessagesOrError.errorValue
+      );
     }
 
     return counselMessagesOrError.value;
   }
 
   static toDomains(entities: CounselMessagesEntity[]): CounselMessages[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter((counselMessage) => counselMessage !== null);
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(counselMessages: CounselMessages): CounselMessagesEntity {
@@ -51,20 +62,24 @@ export class PsqlCounselMessagesMapper {
     entity.counselTechniqueId = counselMessages.counselTechniqueId.getString();
     entity.message = counselMessages.message;
     entity.isUserMessage = counselMessages.isUserMessage;
-    entity.reactedAt = counselMessages.reactedAt ? counselMessages.reactedAt.toISOString() : null;
+    entity.reactedAt = counselMessages.reactedAt
+      ? counselMessages.reactedAt.toISOString()
+      : null;
     entity.reaction = counselMessages.reaction;
     entity.createdAt = counselMessages.createdAt.toISOString();
     entity.updatedAt = counselMessages.updatedAt.toISOString();
-    entity.deletedAt = counselMessages.deletedAt ? counselMessages.deletedAt.toISOString() : null;
+    entity.deletedAt = counselMessages.deletedAt
+      ? counselMessages.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
-  static toEntities(counselMessages: CounselMessages[]): CounselMessagesEntity[] {
-    if (counselMessages.length === 0) {
-      return [];
-    }
-
-    return counselMessages.map((counselMessage) => this.toEntity(counselMessage));
+  static toEntities(
+    counselMessages: CounselMessages[]
+  ): CounselMessagesEntity[] {
+    return (counselMessages ?? []).map((counselMessage) =>
+      this.toEntity(counselMessage)
+    );
   }
 }

--- a/src/services/counselings/infrastructures/counselTechniques/mappers/psql.counselTechniques.mapper.ts
+++ b/src/services/counselings/infrastructures/counselTechniques/mappers/psql.counselTechniques.mapper.ts
@@ -1,13 +1,23 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { CounselTechniquesEntity } from "~shared/core/infrastructure/entities/prompts/CounselTechniques.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { CounselTechniques, CounselTechniquesProps } from "~counselings/domains/counselTechniques/models/counselTechniques";
+import {
+  CounselTechniques,
+  CounselTechniquesProps,
+} from "~counselings/domains/counselTechniques/models/counselTechniques";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlCounselTechniquesMapper {
-  static toDomain(entity: CounselTechniquesEntity): CounselTechniques | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: CounselTechniquesEntity): CounselTechniques;
+  static toDomain(
+    entity: CounselTechniquesEntity | null
+  ): CounselTechniques | null;
+  static toDomain(
+    entity: CounselTechniquesEntity | null
+  ): CounselTechniques | null {
     if (!entity) {
       return null;
     }
@@ -18,30 +28,36 @@ export class PsqlCounselTechniquesMapper {
       context: entity.context,
       instruction: entity.instruction,
       messageThreshold: entity.messageThreshold,
-      nextTechniqueId: entity.nextTechniqueId ? new UniqueEntityId(entity.nextTechniqueId) : null,
+      nextTechniqueId: entity.nextTechniqueId
+        ? new UniqueEntityId(entity.nextTechniqueId)
+        : null,
       isTemporary: entity.isTemporary,
       createdAt: dayjs(entity.createdAt),
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const counselTechniquesOrError = CounselTechniques.create(counselTechniqueProps, new UniqueEntityId(entity.id));
+    const counselTechniquesOrError = CounselTechniques.create(
+      counselTechniqueProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (counselTechniquesOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, counselTechniquesOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        counselTechniquesOrError.errorValue
+      );
     }
 
     return counselTechniquesOrError.value;
   }
 
   static toDomains(entities: CounselTechniquesEntity[]): CounselTechniques[] {
-    if (entities.length === 0) {
-      return [];
-    }
-
-    return entities.map((entity) => this.toDomain(entity)).filter(Boolean) as CounselTechniques[];
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
-  static toEntity(counselTechniques: CounselTechniques): CounselTechniquesEntity {
+  static toEntity(
+    counselTechniques: CounselTechniques
+  ): CounselTechniquesEntity {
     const entity = new CounselTechniquesEntity();
 
     if (!counselTechniques.id.isNewIdentifier()) {
@@ -54,21 +70,23 @@ export class PsqlCounselTechniquesMapper {
     entity.instruction = counselTechniques.instruction;
     entity.messageThreshold = counselTechniques.messageThreshold;
 
-    entity.nextTechniqueId = counselTechniques.nextTechniqueId ? counselTechniques.nextTechniqueId.getString() : null;
+    entity.nextTechniqueId = counselTechniques.nextTechniqueId
+      ? counselTechniques.nextTechniqueId.getString()
+      : null;
     entity.isTemporary = counselTechniques.isTemporary;
 
     entity.createdAt = counselTechniques.createdAt.toISOString();
     entity.updatedAt = counselTechniques.updatedAt.toISOString();
-    entity.deletedAt = counselTechniques.deletedAt ? counselTechniques.deletedAt.toISOString() : null;
+    entity.deletedAt = counselTechniques.deletedAt
+      ? counselTechniques.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
-  static toEntities(counselTechniques: CounselTechniques[]): CounselTechniquesEntity[] {
-    if (counselTechniques.length === 0) {
-      return [];
-    }
-
-    return counselTechniques.map((counsel) => this.toEntity(counsel));
+  static toEntities(
+    counselTechniques: CounselTechniques[]
+  ): CounselTechniquesEntity[] {
+    return (counselTechniques ?? []).map((counsel) => this.toEntity(counsel));
   }
 }

--- a/src/services/counselings/infrastructures/counselors/mappers/psql.counselors.mapper.ts
+++ b/src/services/counselings/infrastructures/counselors/mappers/psql.counselors.mapper.ts
@@ -2,14 +2,23 @@ import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { BubbleEntity } from "~shared/core/infrastructure/entities/counselors/bubble.entity";
 import { CounselorEntity } from "~shared/core/infrastructure/entities/counselors/counselor.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { Bubbles, BubblesProps } from "~counselings/domains/counselors/models/bubbles";
-import { Counselors, CounselorsProps } from "~counselings/domains/counselors/models/counselors";
+import {
+  Bubbles,
+  BubblesProps,
+} from "~counselings/domains/counselors/models/bubbles";
+import {
+  Counselors,
+  CounselorsProps,
+} from "~counselings/domains/counselors/models/counselors";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlCounselorsMapper {
-  static toDomain(entity: CounselorEntity): Counselors | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: CounselorEntity): Counselors;
+  static toDomain(entity: CounselorEntity | null): Counselors | null;
+  static toDomain(entity: CounselorEntity | null): Counselors | null {
     if (!entity) {
       return null;
     }
@@ -24,20 +33,23 @@ export class PsqlCounselorsMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const counselorsOrError = Counselors.create(counselorProps, new UniqueEntityId(entity.id));
+    const counselorsOrError = Counselors.create(
+      counselorProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (counselorsOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, counselorsOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        counselorsOrError.errorValue
+      );
     }
 
     return counselorsOrError.value;
   }
 
   static toDomains(entities: CounselorEntity[]): Counselors[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter((counselor) => counselor !== null);
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(counselors: Counselors): CounselorEntity {
@@ -51,16 +63,15 @@ export class PsqlCounselorsMapper {
     entity.profileImage = counselors.profileImage;
     entity.createdAt = counselors.createdAt.toISOString();
     entity.updatedAt = counselors.updatedAt.toISOString();
-    entity.deletedAt = counselors.deletedAt ? counselors.deletedAt.toISOString() : null;
+    entity.deletedAt = counselors.deletedAt
+      ? counselors.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
   static toEntities(counselors: Counselors[]): CounselorEntity[] {
-    if (counselors.length === 0) {
-      return [];
-    }
-    return counselors.map((counselor) => this.toEntity(counselor));
+    return (counselors ?? []).map((counselor) => this.toEntity(counselor));
   }
 
   static toBubbleDomain(entity: BubbleEntity): Bubbles;
@@ -78,20 +89,23 @@ export class PsqlCounselorsMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const bubblesOrError = Bubbles.create(bubbleProps, new UniqueEntityId(entity.id));
+    const bubblesOrError = Bubbles.create(
+      bubbleProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (bubblesOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, bubblesOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        bubblesOrError.errorValue
+      );
     }
 
     return bubblesOrError.value;
   }
 
   static toBubbleDomains(entities: BubbleEntity[]): Bubbles[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toBubbleDomain(entity)).filter((bubble) => bubble !== null);
+    return (entities ?? []).map((entity) => this.toBubbleDomain(entity));
   }
 
   static toBubbleEntity(counselor: Counselors, bubble: Bubbles): BubbleEntity {

--- a/src/services/counselings/infrastructures/counsels/mappers/psql.counsels.mapper.ts
+++ b/src/services/counselings/infrastructures/counsels/mappers/psql.counsels.mapper.ts
@@ -1,13 +1,19 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { CounselsEntity } from "~shared/core/infrastructure/entities/counsels/Counsels.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { Counsels, CounselsProps } from "~counselings/domains/counsels/models/counsels";
+import {
+  Counsels,
+  CounselsProps,
+} from "~counselings/domains/counsels/models/counsels";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlCounselsMapper {
-  static toDomain(entity: CounselsEntity): Counsels | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: CounselsEntity): Counsels;
+  static toDomain(entity: CounselsEntity | null): Counsels | null;
+  static toDomain(entity: CounselsEntity | null): Counsels | null {
     if (!entity) {
       return null;
     }
@@ -17,27 +23,32 @@ export class PsqlCounselsMapper {
       counselorId: new UniqueEntityId(entity.counselorId),
       counselTechniqueId: new UniqueEntityId(entity.counselTechniqueId),
       promptVersionId: new UniqueEntityId(entity.promptVersionId),
-      counselorUserRelationshipId: new UniqueEntityId(entity.counselorUserRelationshipId),
+      counselorUserRelationshipId: new UniqueEntityId(
+        entity.counselorUserRelationshipId
+      ),
       lastChatedAt: entity.lastChatedAt ? dayjs(entity.lastChatedAt) : null,
       lastMessage: entity.lastMessage,
       createdAt: dayjs(entity.createdAt),
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const counselsOrError = Counsels.create(counselProps, new UniqueEntityId(entity.id));
+    const counselsOrError = Counsels.create(
+      counselProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (counselsOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, counselsOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        counselsOrError.errorValue
+      );
     }
 
     return counselsOrError.value;
   }
 
   static toDomains(entities: CounselsEntity[]): Counsels[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter((counsel) => counsel !== null);
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(counsels: Counsels): CounselsEntity {
@@ -48,23 +59,24 @@ export class PsqlCounselsMapper {
     entity.counselorId = counsels.counselorId.getString();
     entity.counselTechniqueId = counsels.counselTechniqueId.getString();
     entity.promptVersionId = counsels.promptVersionId.getString();
-    entity.counselorUserRelationshipId = counsels.counselorUserRelationshipId.getString();
+    entity.counselorUserRelationshipId =
+      counsels.counselorUserRelationshipId.getString();
 
-    entity.lastChatedAt = counsels.lastChatedAt ? counsels.lastChatedAt.toISOString() : null;
+    entity.lastChatedAt = counsels.lastChatedAt
+      ? counsels.lastChatedAt.toISOString()
+      : null;
     entity.lastMessage = counsels.lastMessage;
 
     entity.createdAt = counsels.createdAt.toISOString();
     entity.updatedAt = counsels.updatedAt.toISOString();
-    entity.deletedAt = counsels.deletedAt ? counsels.deletedAt.toISOString() : null;
+    entity.deletedAt = counsels.deletedAt
+      ? counsels.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
   static toEntities(counsels: Counsels[]): CounselsEntity[] {
-    if (counsels.length === 0) {
-      return [];
-    }
-
-    return counsels.map((counsel) => this.toEntity(counsel));
+    return (counsels ?? []).map((counsel) => this.toEntity(counsel));
   }
 }

--- a/src/services/counselings/infrastructures/episodes/mappers/psql.episodes.mapper.ts
+++ b/src/services/counselings/infrastructures/episodes/mappers/psql.episodes.mapper.ts
@@ -2,8 +2,14 @@ import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { EpisodeEntity } from "~shared/core/infrastructure/entities/counselors/episode.entity";
 import { EpisodeCutSceneEntity } from "~shared/core/infrastructure/entities/counselors/episode-cut-scene.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { EpisodeCutScenes, EpisodeCutScenesProps } from "~counselings/domains/episodes/models/episode-cut-scenes";
-import { Episodes, EpisodesProps } from "~counselings/domains/episodes/models/episodes";
+import {
+  EpisodeCutScenes,
+  EpisodeCutScenesProps,
+} from "~counselings/domains/episodes/models/episode-cut-scenes";
+import {
+  Episodes,
+  EpisodesProps,
+} from "~counselings/domains/episodes/models/episodes";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
@@ -22,15 +28,23 @@ export class PsqlEpisodesMapper {
       title: entity.title,
       requiredRapportThreshold: entity.requiredRapportThreshold,
       isTemporary: entity.isTemporary,
-      cutScenes: entity.cutScenes.map((cutScene) => this.toCutSceneDomain(cutScene)),
+      cutScenes: (entity.cutScenes ?? []).map((cutScene) =>
+        this.toCutSceneDomain(cutScene)
+      ),
       createdAt: dayjs(entity.createdAt),
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const episodesOrError = Episodes.create(episodeProps, new UniqueEntityId(entity.id));
+    const episodesOrError = Episodes.create(
+      episodeProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (episodesOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, episodesOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        episodesOrError.errorValue
+      );
     }
 
     return episodesOrError.value;
@@ -40,7 +54,9 @@ export class PsqlEpisodesMapper {
     if (entities.length === 0) {
       return [];
     }
-    return entities.map((entity) => this.toDomain(entity)).filter((episode) => episode !== null);
+    return entities
+      .map((entity) => this.toDomain(entity))
+      .filter((episode) => episode !== null);
   }
 
   static toEntity(episode: Episodes): EpisodeEntity {
@@ -51,25 +67,30 @@ export class PsqlEpisodesMapper {
     entity.title = episode.title;
     entity.requiredRapportThreshold = episode.requiredRapportThreshold;
     entity.isTemporary = episode.isTemporary;
-    entity.cutScenes = episode.cutScenes.map((cutScene) => this.toCutSceneEntity(episode, cutScene));
+    entity.cutScenes = (episode.cutScenes ?? []).map((cutScene) =>
+      this.toCutSceneEntity(episode, cutScene)
+    );
     entity.createdAt = episode.createdAt.toISOString();
     entity.updatedAt = episode.updatedAt.toISOString();
-    entity.deletedAt = episode.deletedAt ? episode.deletedAt.toISOString() : null;
+    entity.deletedAt = episode.deletedAt
+      ? episode.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
   static toEntities(episodes: Episodes[]): EpisodeEntity[] {
-    if (episodes.length === 0) {
-      return [];
-    }
-    return episodes.map((episode) => this.toEntity(episode));
+    return (episodes ?? []).map((episode) => this.toEntity(episode));
   }
 
   static toCutSceneDomain(entity: null): null;
   static toCutSceneDomain(entity: EpisodeCutSceneEntity): EpisodeCutScenes;
-  static toCutSceneDomain(entity: EpisodeCutSceneEntity | null): EpisodeCutScenes | null;
-  static toCutSceneDomain(entity: EpisodeCutSceneEntity | null): EpisodeCutScenes | null {
+  static toCutSceneDomain(
+    entity: EpisodeCutSceneEntity | null
+  ): EpisodeCutScenes | null;
+  static toCutSceneDomain(
+    entity: EpisodeCutSceneEntity | null
+  ): EpisodeCutScenes | null {
     if (!entity) {
       return null;
     }
@@ -84,23 +105,31 @@ export class PsqlEpisodesMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const cutScenesOrError = EpisodeCutScenes.create(cutSceneProps, new UniqueEntityId(entity.id));
+    const cutScenesOrError = EpisodeCutScenes.create(
+      cutSceneProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (cutScenesOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, cutScenesOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        cutScenesOrError.errorValue
+      );
     }
 
     return cutScenesOrError.value;
   }
 
-  static toCutSceneDomains(entities: EpisodeCutSceneEntity[]): EpisodeCutScenes[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toCutSceneDomain(entity)).filter((cutScene) => cutScene !== null);
+  static toCutSceneDomains(
+    entities: EpisodeCutSceneEntity[]
+  ): EpisodeCutScenes[] {
+    return (entities ?? []).map((entity) => this.toCutSceneDomain(entity));
   }
 
-  static toCutSceneEntity(episode: Episodes, cutScene: EpisodeCutScenes): EpisodeCutSceneEntity {
+  static toCutSceneEntity(
+    episode: Episodes,
+    cutScene: EpisodeCutScenes
+  ): EpisodeCutSceneEntity {
     const entity = new EpisodeCutSceneEntity();
 
     entity.id = cutScene.id.getString();
@@ -111,7 +140,9 @@ export class PsqlEpisodesMapper {
     entity.image = cutScene.image;
     entity.createdAt = cutScene.createdAt.toISOString();
     entity.updatedAt = cutScene.updatedAt.toISOString();
-    entity.deletedAt = cutScene.deletedAt ? cutScene.deletedAt.toISOString() : null;
+    entity.deletedAt = cutScene.deletedAt
+      ? cutScene.deletedAt.toISOString()
+      : null;
 
     return entity;
   }

--- a/src/services/counselings/infrastructures/episodes/typeorm-episodes.repository.ts
+++ b/src/services/counselings/infrastructures/episodes/typeorm-episodes.repository.ts
@@ -10,7 +10,10 @@ import { Repository } from "typeorm";
 
 @Injectable()
 export class TypeormEpisodesRepository extends EpisodesRepository {
-  constructor(@InjectRepository(EpisodeEntity) private readonly episodesRepository: Repository<EpisodeEntity>) {
+  constructor(
+    @InjectRepository(EpisodeEntity)
+    private readonly episodesRepository: Repository<EpisodeEntity>
+  ) {
     super();
   }
 
@@ -25,6 +28,9 @@ export class TypeormEpisodesRepository extends EpisodesRepository {
         counselorId: where.counselorId?.getString(),
         isTemporary: where.isTemporary,
       },
+      relations: {
+        cutScenes: true,
+      },
     });
     if (!episode) {
       return null;
@@ -33,11 +39,17 @@ export class TypeormEpisodesRepository extends EpisodesRepository {
     return PsqlEpisodesMapper.toDomain(episode);
   }
 
-  override async findMany(where: { counselorId?: UniqueEntityId; isTemporary?: boolean }): Promise<Episodes[]> {
+  override async findMany(where: {
+    counselorId?: UniqueEntityId;
+    isTemporary?: boolean;
+  }): Promise<Episodes[]> {
     const episodes = await this.episodesRepository.find({
       where: {
         counselorId: where.counselorId?.getString(),
         isTemporary: where.isTemporary,
+      },
+      relations: {
+        cutScenes: true,
       },
     });
     return PsqlEpisodesMapper.toDomains(episodes);
@@ -45,7 +57,9 @@ export class TypeormEpisodesRepository extends EpisodesRepository {
 
   override async save(episode: Episodes): Promise<Episodes>;
   override async save(episodes: Episodes[]): Promise<Episodes[]>;
-  override async save(episode: Episodes | Episodes[]): Promise<Episodes | Episodes[]> {
+  override async save(
+    episode: Episodes | Episodes[]
+  ): Promise<Episodes | Episodes[]> {
     if (Array.isArray(episode)) {
       const entities = episode.map((e) => PsqlEpisodesMapper.toEntity(e));
       const savedEpisodes = await this.episodesRepository.save(entities);

--- a/src/services/counselings/infrastructures/personaPrompts/mappers/psql.personaPrompts.mapper.ts
+++ b/src/services/counselings/infrastructures/personaPrompts/mappers/psql.personaPrompts.mapper.ts
@@ -1,13 +1,19 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { PersonaPromptEntity } from "~shared/core/infrastructure/entities/prompts/PersonaPrompts.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { PersonaPrompts, PersonaPromptsProps } from "~counselings/domains/personaPrompts/models/personaPrompts";
+import {
+  PersonaPrompts,
+  PersonaPromptsProps,
+} from "~counselings/domains/personaPrompts/models/personaPrompts";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlPersonaPromptsMapper {
-  static toDomain(entity: PersonaPromptEntity): PersonaPrompts | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: PersonaPromptEntity): PersonaPrompts;
+  static toDomain(entity: PersonaPromptEntity | null): PersonaPrompts | null;
+  static toDomain(entity: PersonaPromptEntity | null): PersonaPrompts | null {
     if (!entity) {
       return null;
     }
@@ -18,18 +24,21 @@ export class PsqlPersonaPromptsMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const personaPromptsOrError = PersonaPrompts.create(personaPromptProps, new UniqueEntityId(entity.id));
+    const personaPromptsOrError = PersonaPrompts.create(
+      personaPromptProps,
+      new UniqueEntityId(entity.id)
+    );
     if (personaPromptsOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, personaPromptsOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        personaPromptsOrError.errorValue
+      );
     }
     return personaPromptsOrError.value;
   }
 
   static toDomains(entities: PersonaPromptEntity[]): PersonaPrompts[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter((personaPrompt) => personaPrompt !== null);
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(personaPrompts: PersonaPrompts): PersonaPromptEntity {
@@ -42,14 +51,13 @@ export class PsqlPersonaPromptsMapper {
     entity.body = personaPrompts.body;
     entity.createdAt = personaPrompts.createdAt.toISOString();
     entity.updatedAt = personaPrompts.updatedAt.toISOString();
-    entity.deletedAt = personaPrompts.deletedAt ? personaPrompts.deletedAt.toISOString() : null;
+    entity.deletedAt = personaPrompts.deletedAt
+      ? personaPrompts.deletedAt.toISOString()
+      : null;
     return entity;
   }
 
   static toEntities(personaPrompts: PersonaPrompts[]): PersonaPromptEntity[] {
-    if (personaPrompts.length === 0) {
-      return [];
-    }
-    return personaPrompts.map((prompt) => this.toEntity(prompt));
+    return (personaPrompts ?? []).map((prompt) => this.toEntity(prompt));
   }
 }

--- a/src/services/counselings/infrastructures/promptActivateHistory/mappers/psql.promptActivateHistory.mapper.ts
+++ b/src/services/counselings/infrastructures/promptActivateHistory/mappers/psql.promptActivateHistory.mapper.ts
@@ -1,11 +1,21 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { PromptActivateHistoryEntity } from "~shared/core/infrastructure/entities/prompts/PromptActivateHistory.entity";
-import { PromptActivateHistories, PromptActivateHistoriesProps } from "~counselings/domains/promptActivateHistory/models/promptActivateHistory";
+import {
+  PromptActivateHistories,
+  PromptActivateHistoriesProps,
+} from "~counselings/domains/promptActivateHistory/models/promptActivateHistory";
 
 import dayjs from "dayjs";
 
 export class PsqlPromptActivateHistoryMapper {
-  static toDomain(entity: PromptActivateHistoryEntity): PromptActivateHistories | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: PromptActivateHistoryEntity): PromptActivateHistories;
+  static toDomain(
+    entity: PromptActivateHistoryEntity | null
+  ): PromptActivateHistories | null;
+  static toDomain(
+    entity: PromptActivateHistoryEntity | null
+  ): PromptActivateHistories | null {
     if (!entity) {
       return null;
     }
@@ -16,21 +26,25 @@ export class PsqlPromptActivateHistoryMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const promptActivateHistoryOrError = PromptActivateHistories.create(promptActivateHistoriesProps, new UniqueEntityId(entity.id));
+    const promptActivateHistoryOrError = PromptActivateHistories.create(
+      promptActivateHistoriesProps,
+      new UniqueEntityId(entity.id)
+    );
     if (promptActivateHistoryOrError.isFailure) {
       throw new Error(promptActivateHistoryOrError.errorValue);
     }
     return promptActivateHistoryOrError.value;
   }
 
-  static toDomains(entities: PromptActivateHistoryEntity[]): PromptActivateHistories[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter((promptActivateHistory) => promptActivateHistory !== null);
+  static toDomains(
+    entities: PromptActivateHistoryEntity[]
+  ): PromptActivateHistories[] {
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
-  static toEntity(promptActivateHistory: PromptActivateHistories): PromptActivateHistoryEntity {
+  static toEntity(
+    promptActivateHistory: PromptActivateHistories
+  ): PromptActivateHistoryEntity {
     const entity = new PromptActivateHistoryEntity();
 
     if (!promptActivateHistory.id.isNewIdentifier()) {
@@ -40,14 +54,17 @@ export class PsqlPromptActivateHistoryMapper {
     entity.activatedAt = promptActivateHistory.activatedAt.toISOString();
     entity.createdAt = promptActivateHistory.createdAt.toISOString();
     entity.updatedAt = promptActivateHistory.updatedAt.toISOString();
-    entity.deletedAt = promptActivateHistory.deletedAt ? promptActivateHistory.deletedAt.toISOString() : null;
+    entity.deletedAt = promptActivateHistory.deletedAt
+      ? promptActivateHistory.deletedAt.toISOString()
+      : null;
     return entity;
   }
 
-  static toEntities(promptActivateHistory: PromptActivateHistories[]): PromptActivateHistoryEntity[] {
-    if (promptActivateHistory.length === 0) {
-      return [];
-    }
-    return promptActivateHistory.map((history) => this.toEntity(history));
+  static toEntities(
+    promptActivateHistory: PromptActivateHistories[]
+  ): PromptActivateHistoryEntity[] {
+    return (promptActivateHistory ?? []).map((history) =>
+      this.toEntity(history)
+    );
   }
 }

--- a/src/services/counselings/infrastructures/promptVersions/mappers/psql.counselorScopedPrompts.mapper.ts
+++ b/src/services/counselings/infrastructures/promptVersions/mappers/psql.counselorScopedPrompts.mapper.ts
@@ -1,13 +1,23 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { CounselorScopedPromptEntity } from "~shared/core/infrastructure/entities/prompts/CounselorScopedPrompts.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { CounselorScopedPrompts, CounselorScopedPromptsProps } from "~counselings/domains/promptVersions/models/counselorScopedPrompts";
+import {
+  CounselorScopedPrompts,
+  CounselorScopedPromptsProps,
+} from "~counselings/domains/promptVersions/models/counselorScopedPrompts";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlCounselorScopedPromptsMapper {
-  static toDomain(entity: CounselorScopedPromptEntity): CounselorScopedPrompts | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: CounselorScopedPromptEntity): CounselorScopedPrompts;
+  static toDomain(
+    entity: CounselorScopedPromptEntity | null
+  ): CounselorScopedPrompts | null;
+  static toDomain(
+    entity: CounselorScopedPromptEntity | null
+  ): CounselorScopedPrompts | null {
     if (!entity) {
       return null;
     }
@@ -21,24 +31,30 @@ export class PsqlCounselorScopedPromptsMapper {
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
 
-    const counselorScopedPromptOrError = CounselorScopedPrompts.create(counselorScopedPromptsProps, new UniqueEntityId(entity.id));
+    const counselorScopedPromptOrError = CounselorScopedPrompts.create(
+      counselorScopedPromptsProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (counselorScopedPromptOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, counselorScopedPromptOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        counselorScopedPromptOrError.errorValue
+      );
     }
 
     return counselorScopedPromptOrError.value;
   }
 
-  static toDomains(entities: CounselorScopedPromptEntity[]): CounselorScopedPrompts[] {
-    if (entities.length === 0) {
-      return [];
-    }
-
-    return entities.map((entity) => this.toDomain(entity)).filter(Boolean) as CounselorScopedPrompts[];
+  static toDomains(
+    entities: CounselorScopedPromptEntity[]
+  ): CounselorScopedPrompts[] {
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
-  static toEntity(counselorScopedPrompt: CounselorScopedPrompts): CounselorScopedPromptEntity {
+  static toEntity(
+    counselorScopedPrompt: CounselorScopedPrompts
+  ): CounselorScopedPromptEntity {
     const entity = new CounselorScopedPromptEntity();
 
     if (!counselorScopedPrompt.id.isNewIdentifier()) {
@@ -51,16 +67,16 @@ export class PsqlCounselorScopedPromptsMapper {
 
     entity.createdAt = counselorScopedPrompt.createdAt.toISOString();
     entity.updatedAt = counselorScopedPrompt.updatedAt.toISOString();
-    entity.deletedAt = counselorScopedPrompt.deletedAt ? counselorScopedPrompt.deletedAt.toISOString() : null;
+    entity.deletedAt = counselorScopedPrompt.deletedAt
+      ? counselorScopedPrompt.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
-  static toEntities(promptByCounselors: CounselorScopedPrompts[]): CounselorScopedPromptEntity[] {
-    if (promptByCounselors.length === 0) {
-      return [];
-    }
-
-    return promptByCounselors.map((prompt) => this.toEntity(prompt));
+  static toEntities(
+    promptByCounselors: CounselorScopedPrompts[]
+  ): CounselorScopedPromptEntity[] {
+    return (promptByCounselors ?? []).map((prompt) => this.toEntity(prompt));
   }
 }

--- a/src/services/counselings/infrastructures/promptVersions/mappers/psql.promptVersions.mapper.ts
+++ b/src/services/counselings/infrastructures/promptVersions/mappers/psql.promptVersions.mapper.ts
@@ -2,7 +2,10 @@ import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { PromptVersionEntity } from "~shared/core/infrastructure/entities/prompts/PromptVersions.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
 import { CounselorScopedPrompts } from "~counselings/domains/promptVersions/models/counselorScopedPrompts";
-import { PromptVersions, PromptVersionsProps } from "~counselings/domains/promptVersions/models/promptVersions";
+import {
+  PromptVersions,
+  PromptVersionsProps,
+} from "~counselings/domains/promptVersions/models/promptVersions";
 import { ToneScopedPrompts } from "~counselings/domains/promptVersions/models/toneScopedPrompts";
 import { PsqlCounselorScopedPromptsMapper } from "~counselings/infrastructures/promptVersions/mappers/psql.counselorScopedPrompts.mapper";
 import { PsqlToneScopedPromptsMapper } from "~counselings/infrastructures/promptVersions/mappers/psql.toneScopedPrompts.mapper";
@@ -11,13 +14,18 @@ import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlPromptVersionsMapper {
-  static toDomain(entity: PromptVersionEntity): PromptVersions | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: PromptVersionEntity): PromptVersions;
+  static toDomain(entity: PromptVersionEntity | null): PromptVersions | null;
+  static toDomain(entity: PromptVersionEntity | null): PromptVersions | null {
     if (!entity) {
       return null;
     }
 
-    const counselorScopedPrompts: CounselorScopedPrompts[] = PsqlCounselorScopedPromptsMapper.toDomains(entity.counselorScopedPrompts);
-    const toneScopedPrompts: ToneScopedPrompts[] = PsqlToneScopedPromptsMapper.toDomains(entity.toneScopedPrompts);
+    const counselorScopedPrompts: CounselorScopedPrompts[] =
+      PsqlCounselorScopedPromptsMapper.toDomains(entity.counselorScopedPrompts);
+    const toneScopedPrompts: ToneScopedPrompts[] =
+      PsqlToneScopedPromptsMapper.toDomains(entity.toneScopedPrompts);
 
     const promptVersionsProps: PromptVersionsProps = {
       name: entity.name,
@@ -31,19 +39,22 @@ export class PsqlPromptVersionsMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const promptVersionsOrError = PromptVersions.create(promptVersionsProps, new UniqueEntityId(entity.id));
+    const promptVersionsOrError = PromptVersions.create(
+      promptVersionsProps,
+      new UniqueEntityId(entity.id)
+    );
     if (promptVersionsOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, promptVersionsOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        promptVersionsOrError.errorValue
+      );
     }
 
     return promptVersionsOrError.value;
   }
 
   static toDomains(entities: PromptVersionEntity[]): PromptVersions[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter(Boolean) as PromptVersions[];
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(promptVersions: PromptVersions): PromptVersionEntity {
@@ -53,8 +64,12 @@ export class PsqlPromptVersionsMapper {
       entity.id = promptVersions.id.getString();
     }
 
-    entity.counselorScopedPrompts = PsqlCounselorScopedPromptsMapper.toEntities(promptVersions.counselorScopedPrompts);
-    entity.toneScopedPrompts = PsqlToneScopedPromptsMapper.toEntities(promptVersions.toneScopedPrompts);
+    entity.counselorScopedPrompts = PsqlCounselorScopedPromptsMapper.toEntities(
+      promptVersions.counselorScopedPrompts
+    );
+    entity.toneScopedPrompts = PsqlToneScopedPromptsMapper.toEntities(
+      promptVersions.toneScopedPrompts
+    );
 
     entity.name = promptVersions.name;
     entity.description = promptVersions.description;
@@ -64,15 +79,16 @@ export class PsqlPromptVersionsMapper {
 
     entity.createdAt = promptVersions.createdAt.toISOString();
     entity.updatedAt = promptVersions.updatedAt.toISOString();
-    entity.deletedAt = promptVersions.deletedAt ? promptVersions.deletedAt.toISOString() : null;
+    entity.deletedAt = promptVersions.deletedAt
+      ? promptVersions.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
   static toEntities(promptVersions: PromptVersions[]): PromptVersionEntity[] {
-    if (promptVersions.length === 0) {
-      return [];
-    }
-    return promptVersions.map((promptVersion) => this.toEntity(promptVersion));
+    return (promptVersions ?? []).map((promptVersion) =>
+      this.toEntity(promptVersion)
+    );
   }
 }

--- a/src/services/counselings/infrastructures/promptVersions/mappers/psql.toneScopedPrompts.mapper.ts
+++ b/src/services/counselings/infrastructures/promptVersions/mappers/psql.toneScopedPrompts.mapper.ts
@@ -1,13 +1,23 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { ToneScopedPromptEntity } from "~shared/core/infrastructure/entities/prompts/ToneScopedPrompts.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { ToneScopedPrompts, ToneScopedPromptsProps } from "~counselings/domains/promptVersions/models/toneScopedPrompts";
+import {
+  ToneScopedPrompts,
+  ToneScopedPromptsProps,
+} from "~counselings/domains/promptVersions/models/toneScopedPrompts";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlToneScopedPromptsMapper {
-  static toDomain(entity: ToneScopedPromptEntity): ToneScopedPrompts | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: ToneScopedPromptEntity): ToneScopedPrompts;
+  static toDomain(
+    entity: ToneScopedPromptEntity | null
+  ): ToneScopedPrompts | null;
+  static toDomain(
+    entity: ToneScopedPromptEntity | null
+  ): ToneScopedPrompts | null {
     if (!entity) {
       return null;
     }
@@ -15,28 +25,34 @@ export class PsqlToneScopedPromptsMapper {
     const toneScopedPromptProps: ToneScopedPromptsProps = {
       promptVersionId: new UniqueEntityId(entity.promptVersionId),
       toneId: new UniqueEntityId(entity.toneId),
-      tonePromptId: entity.tonePromptId ? new UniqueEntityId(entity.tonePromptId) : null,
-      firstCounselTechniqueId: entity.firstCounselTechniqueId ? new UniqueEntityId(entity.firstCounselTechniqueId) : null,
+      tonePromptId: entity.tonePromptId
+        ? new UniqueEntityId(entity.tonePromptId)
+        : null,
+      firstCounselTechniqueId: entity.firstCounselTechniqueId
+        ? new UniqueEntityId(entity.firstCounselTechniqueId)
+        : null,
       createdAt: dayjs(entity.createdAt),
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
 
-    const toneScopedPromptOrError = ToneScopedPrompts.create(toneScopedPromptProps, new UniqueEntityId(entity.id));
+    const toneScopedPromptOrError = ToneScopedPrompts.create(
+      toneScopedPromptProps,
+      new UniqueEntityId(entity.id)
+    );
 
     if (toneScopedPromptOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, toneScopedPromptOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        toneScopedPromptOrError.errorValue
+      );
     }
 
     return toneScopedPromptOrError.value;
   }
 
   static toDomains(entities: ToneScopedPromptEntity[]): ToneScopedPrompts[] {
-    if (entities.length === 0) {
-      return [];
-    }
-
-    return entities.map((entity) => this.toDomain(entity)).filter(Boolean) as ToneScopedPrompts[];
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(promptByTones: ToneScopedPrompts): ToneScopedPromptEntity {
@@ -48,21 +64,25 @@ export class PsqlToneScopedPromptsMapper {
 
     entity.promptVersionId = promptByTones.promptVersionId.getString();
     entity.toneId = promptByTones.toneId.getString();
-    entity.tonePromptId = promptByTones.tonePromptId ? promptByTones.tonePromptId.getString() : null;
-    entity.firstCounselTechniqueId = promptByTones.firstCounselTechniqueId ? promptByTones.firstCounselTechniqueId.getString() : null;
+    entity.tonePromptId = promptByTones.tonePromptId
+      ? promptByTones.tonePromptId.getString()
+      : null;
+    entity.firstCounselTechniqueId = promptByTones.firstCounselTechniqueId
+      ? promptByTones.firstCounselTechniqueId.getString()
+      : null;
 
     entity.createdAt = promptByTones.createdAt.toISOString();
     entity.updatedAt = promptByTones.updatedAt.toISOString();
-    entity.deletedAt = promptByTones.deletedAt ? promptByTones.deletedAt.toISOString() : null;
+    entity.deletedAt = promptByTones.deletedAt
+      ? promptByTones.deletedAt.toISOString()
+      : null;
 
     return entity;
   }
 
-  static toEntities(promptByTones: ToneScopedPrompts[]): ToneScopedPromptEntity[] {
-    if (promptByTones.length === 0) {
-      return [];
-    }
-
-    return promptByTones.map((prompt) => this.toEntity(prompt));
+  static toEntities(
+    promptByTones: ToneScopedPrompts[]
+  ): ToneScopedPromptEntity[] {
+    return (promptByTones ?? []).map((prompt) => this.toEntity(prompt));
   }
 }

--- a/src/services/counselings/infrastructures/tonePrompts/mappers/psql.tonePrompts.mapper.ts
+++ b/src/services/counselings/infrastructures/tonePrompts/mappers/psql.tonePrompts.mapper.ts
@@ -1,13 +1,19 @@
 import { UniqueEntityId } from "~shared/core/domain/UniqueEntityId";
 import { TonePromptEntity } from "~shared/core/infrastructure/entities/prompts/TonePrompts.entity";
 import { HttpStatusBasedRpcException } from "~shared/filters/exceptions";
-import { TonePrompts, TonePromptsProps } from "~counselings/domains/tonePrompts/models/tonePrompts";
+import {
+  TonePrompts,
+  TonePromptsProps,
+} from "~counselings/domains/tonePrompts/models/tonePrompts";
 
 import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlTonePromptsMapper {
-  static toDomain(entity: TonePromptEntity): TonePrompts | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: TonePromptEntity): TonePrompts;
+  static toDomain(entity: TonePromptEntity | null): TonePrompts | null;
+  static toDomain(entity: TonePromptEntity | null): TonePrompts | null {
     if (!entity) {
       return null;
     }
@@ -18,18 +24,21 @@ export class PsqlTonePromptsMapper {
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
     };
-    const tonePromptsOrError = TonePrompts.create(tonePromptProps, new UniqueEntityId(entity.id));
+    const tonePromptsOrError = TonePrompts.create(
+      tonePromptProps,
+      new UniqueEntityId(entity.id)
+    );
     if (tonePromptsOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, tonePromptsOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        tonePromptsOrError.errorValue
+      );
     }
     return tonePromptsOrError.value;
   }
 
   static toDomains(entities: TonePromptEntity[]): TonePrompts[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter((tonePrompt) => tonePrompt !== null);
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(tonePrompts: TonePrompts): TonePromptEntity {
@@ -42,14 +51,13 @@ export class PsqlTonePromptsMapper {
     entity.body = tonePrompts.body;
     entity.createdAt = tonePrompts.createdAt.toISOString();
     entity.updatedAt = tonePrompts.updatedAt.toISOString();
-    entity.deletedAt = tonePrompts.deletedAt ? tonePrompts.deletedAt.toISOString() : null;
+    entity.deletedAt = tonePrompts.deletedAt
+      ? tonePrompts.deletedAt.toISOString()
+      : null;
     return entity;
   }
 
   static toEntities(tonePrompts: TonePrompts[]): TonePromptEntity[] {
-    if (tonePrompts.length === 0) {
-      return [];
-    }
-    return tonePrompts.map((prompt) => this.toEntity(prompt));
+    return (tonePrompts ?? []).map((prompt) => this.toEntity(prompt));
   }
 }

--- a/src/services/counselings/infrastructures/tones/mappers/psql.tones.mapper.ts
+++ b/src/services/counselings/infrastructures/tones/mappers/psql.tones.mapper.ts
@@ -7,7 +7,10 @@ import { HttpStatus } from "@nestjs/common";
 import dayjs from "dayjs";
 
 export class PsqlTonesMapper {
-  static toDomain(entity: ToneEntity): Tones | null {
+  static toDomain(entity: null): null;
+  static toDomain(entity: ToneEntity): Tones;
+  static toDomain(entity: ToneEntity | null): Tones | null;
+  static toDomain(entity: ToneEntity | null): Tones | null {
     if (!entity) {
       return null;
     }
@@ -22,17 +25,17 @@ export class PsqlTonesMapper {
     const tonesOrError = Tones.create(toneProps, new UniqueEntityId(entity.id));
 
     if (tonesOrError.isFailure) {
-      throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, tonesOrError.errorValue);
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        tonesOrError.errorValue
+      );
     }
 
     return tonesOrError.value;
   }
 
   static toDomains(entities: ToneEntity[]): Tones[] {
-    if (entities.length === 0) {
-      return [];
-    }
-    return entities.map((entity) => this.toDomain(entity)).filter((tone) => tone !== null);
+    return (entities ?? []).map((entity) => this.toDomain(entity));
   }
 
   static toEntity(tones: Tones): ToneEntity {
@@ -49,10 +52,6 @@ export class PsqlTonesMapper {
   }
 
   static toEntities(tones: Tones[]): ToneEntity[] {
-    if (tones.length === 0) {
-      return [];
-    }
-
-    return tones.map((tone) => this.toEntity(tone));
+    return (tones ?? []).map((tone) => this.toEntity(tone));
   }
 }

--- a/src/services/counselings/presentations/grpc/command/counsels-command.controller.ts
+++ b/src/services/counselings/presentations/grpc/command/counsels-command.controller.ts
@@ -43,8 +43,8 @@ export class GrpcCounselCommandController {
       });
     return create(CreateCounselResponseSchema, {
       counsel: SchemaCounselsMapper.toCounselProto(counsel),
-      counselMessages: counselMessages.map(
-        SchemaCounselsMapper.toCounselMessageProto
+      counselMessages: (counselMessages ?? []).map((counselMessage) =>
+        SchemaCounselsMapper.toCounselMessageProto(counselMessage)
       ),
     });
   }

--- a/src/services/counselings/presentations/grpc/counselPrompts.mapper.ts
+++ b/src/services/counselings/presentations/grpc/counselPrompts.mapper.ts
@@ -25,7 +25,18 @@ import {
 import { create } from "@bufbuild/protobuf";
 
 export class SchemaCounselPromptsMapper {
-  static toPromptVersionProto(promptVersion: PromptVersions): PromptVersion {
+  static toPromptVersionProto(promptVersion: null): null;
+  static toPromptVersionProto(promptVersion: PromptVersions): PromptVersion;
+  static toPromptVersionProto(
+    promptVersion: PromptVersions | null
+  ): PromptVersion | null;
+  static toPromptVersionProto(
+    promptVersion: PromptVersions | null
+  ): PromptVersion | null {
+    if (!promptVersion) {
+      return null;
+    }
+
     return create(PromptVersionSchema, {
       id: promptVersion.id.getString(),
       name: promptVersion.name,
@@ -33,60 +44,131 @@ export class SchemaCounselPromptsMapper {
       isActive: promptVersion.isActive,
       isTemporary: promptVersion.isTemporary,
       isBookmarked: promptVersion.isBookmarked,
-      counselorScopedPrompts: promptVersion.counselorScopedPrompts.map((counselorScopedPrompt) =>
-        SchemaCounselPromptsMapper.toCounselorScopedPromptProto(counselorScopedPrompt),
+      counselorScopedPrompts: promptVersion.counselorScopedPrompts.map(
+        (counselorScopedPrompt) =>
+          SchemaCounselPromptsMapper.toCounselorScopedPromptProto(
+            counselorScopedPrompt
+          )
       ),
-      toneScopedPrompts: promptVersion.toneScopedPrompts.map((toneScopedPrompt) => SchemaCounselPromptsMapper.toToneScopedPromptProto(toneScopedPrompt)),
+      toneScopedPrompts: promptVersion.toneScopedPrompts.map(
+        (toneScopedPrompt) =>
+          SchemaCounselPromptsMapper.toToneScopedPromptProto(toneScopedPrompt)
+      ),
       createdAt: promptVersion.createdAt.toISOString(),
       updatedAt: promptVersion.updatedAt.toISOString(),
-      deletedAt: promptVersion.deletedAt ? promptVersion.deletedAt.toISOString() : undefined,
+      deletedAt: promptVersion.deletedAt
+        ? promptVersion.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toCounselorScopedPromptProto(counselorScopedPrompt: CounselorScopedPrompts): CounselorScopedPrompt {
+  static toCounselorScopedPromptProto(counselorScopedPrompt: null): null;
+  static toCounselorScopedPromptProto(
+    counselorScopedPrompt: CounselorScopedPrompts
+  ): CounselorScopedPrompt;
+  static toCounselorScopedPromptProto(
+    counselorScopedPrompt: CounselorScopedPrompts | null
+  ): CounselorScopedPrompt | null;
+  static toCounselorScopedPromptProto(
+    counselorScopedPrompt: CounselorScopedPrompts | null
+  ): CounselorScopedPrompt | null {
+    if (!counselorScopedPrompt) {
+      return null;
+    }
     return create(CounselorScopedPromptSchema, {
       counselorId: counselorScopedPrompt.counselorId.getString(),
       personaPromptId: counselorScopedPrompt.personaPromptId.getString(),
       createdAt: counselorScopedPrompt.createdAt.toISOString(),
       updatedAt: counselorScopedPrompt.updatedAt.toISOString(),
-      deletedAt: counselorScopedPrompt.deletedAt ? counselorScopedPrompt.deletedAt.toISOString() : undefined,
+      deletedAt: counselorScopedPrompt.deletedAt
+        ? counselorScopedPrompt.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toToneScopedPromptProto(toneScopedPrompt: ToneScopedPrompts): ToneScopedPrompt {
+  static toToneScopedPromptProto(
+    toneScopedPrompt: ToneScopedPrompts
+  ): ToneScopedPrompt;
+  static toToneScopedPromptProto(
+    toneScopedPrompt: ToneScopedPrompts | null
+  ): ToneScopedPrompt | null;
+  static toToneScopedPromptProto(
+    toneScopedPrompt: ToneScopedPrompts | null
+  ): ToneScopedPrompt | null {
+    if (!toneScopedPrompt) {
+      return null;
+    }
     return create(ToneScopedPromptSchema, {
       toneId: toneScopedPrompt.toneId.getString(),
-      tonePromptId: toneScopedPrompt.tonePromptId ? toneScopedPrompt.tonePromptId.getString() : undefined,
-      firstCounselTechniqueId: toneScopedPrompt.firstCounselTechniqueId ? toneScopedPrompt.firstCounselTechniqueId.getString() : undefined,
+      tonePromptId: toneScopedPrompt.tonePromptId
+        ? toneScopedPrompt.tonePromptId.getString()
+        : undefined,
+      firstCounselTechniqueId: toneScopedPrompt.firstCounselTechniqueId
+        ? toneScopedPrompt.firstCounselTechniqueId.getString()
+        : undefined,
       createdAt: toneScopedPrompt.createdAt.toISOString(),
       updatedAt: toneScopedPrompt.updatedAt.toISOString(),
-      deletedAt: toneScopedPrompt.deletedAt ? toneScopedPrompt.deletedAt.toISOString() : undefined,
+      deletedAt: toneScopedPrompt.deletedAt
+        ? toneScopedPrompt.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toPersonaPromptProto(personaPrompt: PersonaPrompts): PersonaPrompt {
+  static toPersonaPromptProto(personaPrompt: null): null;
+  static toPersonaPromptProto(personaPrompt: PersonaPrompts): PersonaPrompt;
+  static toPersonaPromptProto(
+    personaPrompt: PersonaPrompts | null
+  ): PersonaPrompt | null;
+  static toPersonaPromptProto(
+    personaPrompt: PersonaPrompts | null
+  ): PersonaPrompt | null {
+    if (!personaPrompt) {
+      return null;
+    }
     return create(PersonaPromptSchema, {
       id: personaPrompt.id.getString(),
       body: personaPrompt.body,
       counselorId: personaPrompt.counselorId.getString(),
       createdAt: personaPrompt.createdAt.toISOString(),
       updatedAt: personaPrompt.updatedAt.toISOString(),
-      deletedAt: personaPrompt.deletedAt ? personaPrompt.deletedAt.toISOString() : undefined,
+      deletedAt: personaPrompt.deletedAt
+        ? personaPrompt.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toTonePromptProto(tonePrompt: TonePrompts): TonePrompt {
+  static toTonePromptProto(tonePrompt: null): null;
+  static toTonePromptProto(tonePrompt: TonePrompts): TonePrompt;
+  static toTonePromptProto(tonePrompt: TonePrompts | null): TonePrompt | null;
+  static toTonePromptProto(tonePrompt: TonePrompts | null): TonePrompt | null {
+    if (!tonePrompt) {
+      return null;
+    }
     return create(TonePromptSchema, {
       id: tonePrompt.id.getString(),
       body: tonePrompt.body,
       toneId: tonePrompt.toneId.getString(),
       createdAt: tonePrompt.createdAt.toISOString(),
       updatedAt: tonePrompt.updatedAt.toISOString(),
-      deletedAt: tonePrompt.deletedAt ? tonePrompt.deletedAt.toISOString() : undefined,
+      deletedAt: tonePrompt.deletedAt
+        ? tonePrompt.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toCounselTechniqueProto(counselTechnique: CounselTechniques): CounselTechnique {
+  static toCounselTechniqueProto(counselTechnique: null): null;
+  static toCounselTechniqueProto(
+    counselTechnique: CounselTechniques
+  ): CounselTechnique;
+  static toCounselTechniqueProto(
+    counselTechnique: CounselTechniques | null
+  ): CounselTechnique | null;
+  static toCounselTechniqueProto(
+    counselTechnique: CounselTechniques | null
+  ): CounselTechnique | null {
+    if (!counselTechnique) {
+      return null;
+    }
     return create(CounselTechniqueSchema, {
       id: counselTechnique.id.getString(),
       name: counselTechnique.name,
@@ -95,22 +177,40 @@ export class SchemaCounselPromptsMapper {
       instruction: counselTechnique.instruction,
       messageThreshold: counselTechnique.messageThreshold,
       isTemporary: counselTechnique.isTemporary,
-      nextCounselTechniqueId: counselTechnique.nextTechniqueId ? counselTechnique.nextTechniqueId.getString() : undefined,
+      nextCounselTechniqueId: counselTechnique.nextTechniqueId
+        ? counselTechnique.nextTechniqueId.getString()
+        : undefined,
       createdAt: counselTechnique.createdAt.toISOString(),
       updatedAt: counselTechnique.updatedAt.toISOString(),
-      deletedAt: counselTechnique.deletedAt ? counselTechnique.deletedAt.toISOString() : undefined,
+      deletedAt: counselTechnique.deletedAt
+        ? counselTechnique.deletedAt.toISOString()
+        : undefined,
     });
   }
 
   // PromptActivateHistory
-  static toPromptActivateHistoryProto(promptActivateHistory: PromptActivateHistories): PromptActivateHistory {
+  static toPromptActivateHistoryProto(promptActivateHistory: null): null;
+  static toPromptActivateHistoryProto(
+    promptActivateHistory: PromptActivateHistories
+  ): PromptActivateHistory;
+  static toPromptActivateHistoryProto(
+    promptActivateHistory: PromptActivateHistories | null
+  ): PromptActivateHistory | null;
+  static toPromptActivateHistoryProto(
+    promptActivateHistory: PromptActivateHistories | null
+  ): PromptActivateHistory | null {
+    if (!promptActivateHistory) {
+      return null;
+    }
     return create(PromptActivateHistorySchema, {
       id: promptActivateHistory.id.getString(),
       promptVersionId: promptActivateHistory.promptVersionId.getString(),
       activatedAt: promptActivateHistory.activatedAt.toISOString(),
       createdAt: promptActivateHistory.createdAt.toISOString(),
       updatedAt: promptActivateHistory.updatedAt.toISOString(),
-      deletedAt: promptActivateHistory.deletedAt ? promptActivateHistory.deletedAt.toISOString() : undefined,
+      deletedAt: promptActivateHistory.deletedAt
+        ? promptActivateHistory.deletedAt.toISOString()
+        : undefined,
     });
   }
 }

--- a/src/services/counselings/presentations/grpc/counselors.mapper.ts
+++ b/src/services/counselings/presentations/grpc/counselors.mapper.ts
@@ -13,7 +13,13 @@ import {
 import { create } from "@bufbuild/protobuf";
 
 export class SchemaCounselorsMapper {
-  static toCounselorProto(counselor: Counselors): Counselor {
+  static toCounselorProto(counselor: null): null;
+  static toCounselorProto(counselor: Counselors): Counselor;
+  static toCounselorProto(counselor: Counselors | null): Counselor | null;
+  static toCounselorProto(counselor: Counselors | null): Counselor | null {
+    if (!counselor) {
+      return null;
+    }
     return create(CounselorSchema, {
       id: counselor.id.getString(),
       toneId: counselor.toneId.getString(),
@@ -22,11 +28,19 @@ export class SchemaCounselorsMapper {
       gender: counselor.gender,
       createdAt: counselor.createdAt.toISOString(),
       updatedAt: counselor.updatedAt.toISOString(),
-      deletedAt: counselor.deletedAt ? counselor.deletedAt.toISOString() : undefined,
+      deletedAt: counselor.deletedAt
+        ? counselor.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toToneProto(tone: Tones): Tone {
+  static toToneProto(tone: null): null;
+  static toToneProto(tone: Tones): Tone;
+  static toToneProto(tone: Tones | null): Tone | null;
+  static toToneProto(tone: Tones | null): Tone | null {
+    if (!tone) {
+      return null;
+    }
     return create(ToneSchema, {
       id: tone.id.getString(),
       name: tone.name,
@@ -37,7 +51,13 @@ export class SchemaCounselorsMapper {
     });
   }
 
-  static toBubbleProto(bubble: Bubbles): Bubble {
+  static toBubbleProto(bubble: null): null;
+  static toBubbleProto(bubble: Bubbles): Bubble;
+  static toBubbleProto(bubble: Bubbles | null): Bubble | null;
+  static toBubbleProto(bubble: Bubbles | null): Bubble | null {
+    if (!bubble) {
+      return null;
+    }
     return create(BubbleSchema, {
       id: bubble.id.getString(),
       question: bubble.question,

--- a/src/services/counselings/presentations/grpc/counsels.mapper.ts
+++ b/src/services/counselings/presentations/grpc/counsels.mapper.ts
@@ -1,37 +1,67 @@
 import { CounselMessages } from "~counselings/domains/counselMessages/models/counselMessages";
 import { Counsels } from "~counselings/domains/counsels/models/counsels";
-import { Counsel, CounselMessage, CounselMessageSchema, CounselSchema } from "~proto/com/hearlers/v1/model/counsel_pb";
+import {
+  Counsel,
+  CounselMessage,
+  CounselMessageSchema,
+  CounselSchema,
+} from "~proto/com/hearlers/v1/model/counsel_pb";
 
 import { create } from "@bufbuild/protobuf";
 
 export class SchemaCounselsMapper {
-  static toCounselProto(counsel: Counsels): Counsel {
+  static toCounselProto(counsel: null): null;
+  static toCounselProto(counsel: Counsels): Counsel;
+  static toCounselProto(counsel: Counsels | null): Counsel | null;
+  static toCounselProto(counsel: Counsels | null): Counsel | null {
+    if (!counsel) {
+      return null;
+    }
     return create(CounselSchema, {
       id: counsel.id.getString(),
       counselorId: counsel.counselorId.getString(),
       userId: counsel.userId.getString(),
       lastMessage: counsel.lastMessage ?? undefined,
-      lastChatedAt: counsel.lastChatedAt ? counsel.lastChatedAt.toISOString() : undefined,
+      lastChatedAt: counsel.lastChatedAt
+        ? counsel.lastChatedAt.toISOString()
+        : undefined,
       promptVersionId: counsel.promptVersionId.getString(),
       counselTechniqueId: counsel.counselTechniqueId.getString(),
-      counselorUserRelationshipId: counsel.counselorUserRelationshipId.getString(),
+      counselorUserRelationshipId:
+        counsel.counselorUserRelationshipId.getString(),
       createdAt: counsel.createdAt.toISOString(),
       updatedAt: counsel.updatedAt.toISOString(),
-      deletedAt: counsel.deletedAt ? counsel.deletedAt.toISOString() : undefined,
+      deletedAt: counsel.deletedAt
+        ? counsel.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toCounselMessageProto(counselMessage: CounselMessages): CounselMessage {
+  static toCounselMessageProto(counselMessage: null): null;
+  static toCounselMessageProto(counselMessage: CounselMessages): CounselMessage;
+  static toCounselMessageProto(
+    counselMessage: CounselMessages | null
+  ): CounselMessage | null;
+  static toCounselMessageProto(
+    counselMessage: CounselMessages | null
+  ): CounselMessage | null {
+    if (!counselMessage) {
+      return null;
+    }
     return create(CounselMessageSchema, {
       id: counselMessage.id.getString(),
       counselId: counselMessage.counselId.getString(),
       message: counselMessage.message,
       isUserMessage: counselMessage.isUserMessage,
-      reactedAt: counselMessage.reactedAt ? counselMessage.reactedAt.toISOString() : undefined,
+      reactedAt: counselMessage.reactedAt
+        ? counselMessage.reactedAt.toISOString()
+        : undefined,
       reaction: counselMessage.reaction ?? undefined,
       createdAt: counselMessage.createdAt.toISOString(),
       updatedAt: counselMessage.updatedAt.toISOString(),
-      deletedAt: counselMessage.deletedAt ? counselMessage.deletedAt.toISOString() : undefined,
+      deletedAt: counselMessage.deletedAt
+        ? counselMessage.deletedAt.toISOString()
+        : undefined,
     });
   }
 

--- a/src/services/counselings/presentations/grpc/episodes.mapper.ts
+++ b/src/services/counselings/presentations/grpc/episodes.mapper.ts
@@ -10,21 +10,41 @@ import {
 import { create } from "@bufbuild/protobuf";
 
 export class SchemaEpisodesMapper {
-  static toEpisodeProto(episode: Episodes): Episode {
+  static toEpisodeProto(episode: null): null;
+  static toEpisodeProto(episode: Episodes): Episode;
+  static toEpisodeProto(episode: Episodes | null): Episode | null;
+  static toEpisodeProto(episode: Episodes | null): Episode | null {
+    if (!episode) {
+      return null;
+    }
     return create(EpisodeSchema, {
       id: episode.id.getString(),
       counselorId: episode.counselorId.getString(),
       title: episode.title,
       requiredRapportThreshold: episode.requiredRapportThreshold,
       isTemporary: episode.isTemporary,
-      cutScenes: episode.cutScenes.map((cutScene) => this.toEpisodeCutSceneProto(cutScene)),
+      cutScenes: (episode.cutScenes ?? []).map((cutScene) =>
+        SchemaEpisodesMapper.toEpisodeCutSceneProto(cutScene)
+      ),
       createdAt: episode.createdAt.toISOString(),
       updatedAt: episode.updatedAt.toISOString(),
-      deletedAt: episode.deletedAt ? episode.deletedAt.toISOString() : undefined,
+      deletedAt: episode.deletedAt
+        ? episode.deletedAt.toISOString()
+        : undefined,
     });
   }
 
-  static toEpisodeCutSceneProto(cutScene: EpisodeCutScenes): EpisodeCutScene {
+  static toEpisodeCutSceneProto(cutScene: null): null;
+  static toEpisodeCutSceneProto(cutScene: EpisodeCutScenes): EpisodeCutScene;
+  static toEpisodeCutSceneProto(
+    cutScene: EpisodeCutScenes | null
+  ): EpisodeCutScene | null;
+  static toEpisodeCutSceneProto(
+    cutScene: EpisodeCutScenes | null
+  ): EpisodeCutScene | null {
+    if (!cutScene) {
+      return null;
+    }
     return create(EpisodeCutSceneSchema, {
       id: cutScene.id.getString(),
       episodeId: cutScene.episodeId.getString(),
@@ -34,7 +54,9 @@ export class SchemaEpisodesMapper {
       image: cutScene.image,
       createdAt: cutScene.createdAt.toISOString(),
       updatedAt: cutScene.updatedAt.toISOString(),
-      deletedAt: cutScene.deletedAt ? cutScene.deletedAt.toISOString() : undefined,
+      deletedAt: cutScene.deletedAt
+        ? cutScene.deletedAt.toISOString()
+        : undefined,
     });
   }
 }


### PR DESCRIPTION
## 1. 타입 추론 강화
mapper를 사용할때 현재의 시그니처인   `static toDomain(entity: CouponsEntity | null): Coupon | null` 은 실제 타입에 따른 결과값 보장을 해주지 않습니다. 즉
![image](https://github.com/user-attachments/assets/a0d77a2b-e352-460f-9c7c-be9a01087e97)

이런 케이스에서
![image](https://github.com/user-attachments/assets/1c7fbbcb-0623-4d31-aa73-dc39becb2b35)

매핑된 도메인이 domain | null 로 추론됩니다.

따라 오버로딩을 통해 시그니처를 명시하여, 파라미터에 따른 결과값 타입을 보장합니다.
![image](https://github.com/user-attachments/assets/055bd34b-3e7b-48cf-a9d2-c8fe49dd6643)

이 케이스에선
![image](https://github.com/user-attachments/assets/7fd52506-1816-4d7a-9853-57721fc9ffb6)


null로 추론되지 않습니다

## 2. undefined 처리 강화
또한 외부에서 데이터가 들어오는 경우 (db, rpc등) []로 타입이 선언되어있는데요 복수 데이터인 경우
externalData.map() 하면 컴파일러가 안잡습니다.

근데 db에서 조인을 안한다든가, 허구언날 null이나 undefined로 오는 proto에서 런타임에서 null.map을 자주 해서 500이 자주 뜨더라구요
그래서 
<img width="665" alt="image" src="https://github.com/user-attachments/assets/43e4eced-521a-4e2f-a5c2-fd9489fce1f1" />
<img width="546" alt="image" src="https://github.com/user-attachments/assets/40881a39-a7ca-4a0c-95fe-8bb1c3ea10ed" />

이렇게 보강처리 했습니다 기존 코드보다 짧으면서 .map처리 안전하게 합니다