### PR TITLE
feat: 상담 테크닉 평가 구현

### DIFF
--- a/src/common/shared/utils/rpc.ts
+++ b/src/common/shared/utils/rpc.ts
@@ -62,6 +62,8 @@ export function httpStatusToGrpc(httpStatus: HttpStatus): status {
       return status.INTERNAL;
     case HttpStatus.SERVICE_UNAVAILABLE:
       return status.UNAVAILABLE;
+    case HttpStatus.NOT_ACCEPTABLE:
+      return status.FAILED_PRECONDITION;
     default:
       return status.UNKNOWN; // 기본값
   }

--- a/src/services/counselings/applications/counsel-managements/README.md
+++ b/src/services/counselings/applications/counsel-managements/README.md
@@ -1,0 +1,5 @@
+## 설계 원칙
+
+외부에 export 해야하는 로직은 facade class에만 응집한다.
+support 디렉토리에 있는 class는 상호간 참조 금지, 오직 도메인 서비스만 DI 가능하다.
+그외의 class는 support class, 도메인 서비스를 마음대로 DI 가능하다. 다만, 순환 참조를 주의한다.

--- a/src/services/counselings/applications/counsel-managements/counsel-managements.module.ts
+++ b/src/services/counselings/applications/counsel-managements/counsel-managements.module.ts
@@ -1,10 +1,12 @@
 import { CounselManagementsFacade } from "~counselings/applications/counsel-managements/counsel-managements.facade";
 import { CounselingOrchestrator } from "~counselings/applications/counsel-managements/counseling.orchestrator";
 import { AIResponseGenerator } from "~counselings/applications/counsel-managements/support/ai-response.generator";
+import { ContextManager } from "~counselings/applications/counsel-managements/support/context.manager";
 import { ConversationHistoryBuilder } from "~counselings/applications/counsel-managements/support/conversation-history.builder";
 import { MessageManager } from "~counselings/applications/counsel-managements/support/message.manager";
 import { SystemPromptBuilder } from "~counselings/applications/counsel-managements/support/system-prompt.builder";
 import { TechniqueManager } from "~counselings/applications/counsel-managements/support/technique.manager";
+import { TechniqueEvaluationParser } from "~counselings/applications/counsel-managements/support/technique-evaluation.parser";
 import { CounselMessagesModule } from "~counselings/domains/counselMessages/counselMessages.module";
 import { CounselorsModule } from "~counselings/domains/counselors/counselors.module";
 import { CounselsModule } from "~counselings/domains/counsels/counsels.module";
@@ -37,11 +39,16 @@ import { AssistantAgentModule } from "~common/support/assistant-agents/assistant
     // Facade
     CounselManagementsFacade,
 
+    // Support Services
     AIResponseGenerator,
     ConversationHistoryBuilder,
     MessageManager,
     SystemPromptBuilder,
     TechniqueManager,
+    TechniqueEvaluationParser,
+    ContextManager,
+
+    // Main Orchestrator
     CounselingOrchestrator,
   ],
   exports: [CounselManagementsFacade],

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -15,6 +15,7 @@ import { CounselInfo } from "~counselings/domains/counsels/models/counsel.info";
 
 import { Injectable, Logger } from "@nestjs/common";
 import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
+import { Propagation, Transactional } from "typeorm-transactional";
 
 /**
  * 상담 진행의 전체 흐름을 관리하는 메인 오케스트레이터 서비스
@@ -40,6 +41,7 @@ export class CounselingOrchestrator {
    * @param request 상담 진행 요청
    * @returns 상담 진행 응답
    */
+  @Transactional()
   async proceedCounseling(request: { counselId: UniqueEntityId; userMessage: string }): Promise<{
     counsel: CounselInfo;
     createdCounselMessage: CounselMessageInfo;
@@ -120,6 +122,7 @@ export class CounselingOrchestrator {
    * @param session 상담 세션
    * @param latestMessage 최신 메시지
    */
+  @Transactional({ propagation: Propagation.REQUIRES_NEW })
   private evaluateTechniqueTransitionInBackground(session: CounselSession): void {
     // 백그라운드 처리를 위해 Promise.resolve()를 사용
     Promise.resolve()

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -1,17 +1,19 @@
 import { CounselSession } from "~counselings/applications/counsel-managements/models/counsel-session";
 import { AIResponseGenerator } from "~counselings/applications/counsel-managements/support/ai-response.generator";
+import { ContextManager } from "~counselings/applications/counsel-managements/support/context.manager";
 import { ConversationHistoryBuilder } from "~counselings/applications/counsel-managements/support/conversation-history.builder";
 import { MessageManager } from "~counselings/applications/counsel-managements/support/message.manager";
 import { SystemPromptBuilder } from "~counselings/applications/counsel-managements/support/system-prompt.builder";
-import { TechniqueManager } from "~counselings/applications/counsel-managements/support/technique.manager";
+import {
+  TechniqueEvaluationRequest,
+  TechniqueManager,
+} from "~counselings/applications/counsel-managements/support/technique.manager";
+import { TechniqueEvaluationParser } from "~counselings/applications/counsel-managements/support/technique-evaluation.parser";
+import { TechniqueTransitionDecision } from "~counselings/applications/counsel-managements/types/technique.type";
 import { CounselMessageInfo } from "~counselings/domains/counselMessages/models/counselMessage.info";
-import { CounselorsService } from "~counselings/domains/counselors/counselors.service";
-import { CounselsService } from "~counselings/domains/counsels/counsels.service";
 import { CounselInfo } from "~counselings/domains/counsels/models/counsel.info";
-import { CounselTechniquesService } from "~counselings/domains/counselTechniques/counselTechniques.service";
-import { PromptVersionsService } from "~counselings/domains/promptVersions/promptVersions.service";
 
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
 
 /**
@@ -20,21 +22,17 @@ import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
  */
 @Injectable()
 export class CounselingOrchestrator {
-  private readonly TIME_DURATION_FOR_PROMPT_RESET = 1000 * 60 * 60 * 6; // 6 hours
+  private readonly logger = new Logger(CounselingOrchestrator.name);
 
   constructor(
-    // 도메인 서비스들
-    private readonly counselService: CounselsService,
-    private readonly counselorService: CounselorsService,
-    private readonly promptVersionsService: PromptVersionsService,
-    private readonly counselTechniqueService: CounselTechniquesService,
-
     // 애플리케이션 서비스들
     private readonly techniqueManager: TechniqueManager,
     private readonly promptBuilder: SystemPromptBuilder,
     private readonly historyBuilder: ConversationHistoryBuilder,
     private readonly messageManager: MessageManager,
     private readonly aiGenerator: AIResponseGenerator,
+    private readonly contextManager: ContextManager,
+    private readonly techniqueEvaluationParser: TechniqueEvaluationParser,
   ) {}
 
   /**
@@ -50,14 +48,12 @@ export class CounselingOrchestrator {
     const { counselId, userMessage } = request;
 
     // 1. 세션 컨텍스트 구성
-    let session = await this.buildCounselSession(counselId);
+    let session = await this.contextManager.buildCounselSession(counselId);
 
-    // 2. 상담기법 관리 (초기화 + 변경 체크)
-    const techniqueResult = await this.techniqueManager.manageTechnique({
+    // 2. 현재 상담기법 조회
+    const techniqueResult = await this.techniqueManager.getCurrentTechnique({
       counsel: session.getCounsel(),
       messages: session.getMessages(),
-      firstCounselTechniqueId: session.getToneScopedPrompt().firstCounselTechniqueId,
-      timeDurationForReset: this.TIME_DURATION_FOR_PROMPT_RESET,
     });
 
     // 세션 업데이트 (상담 정보 + 상담기법)
@@ -95,50 +91,106 @@ export class CounselingOrchestrator {
     );
 
     // 7. 시스템 메시지 생성 및 저장
-    const createdSystemMessage = await this.messageManager.createSystemMessage({
+    const createdAssistantMessage = await this.messageManager.createAssistantMessage({
       counselId: new UniqueEntityId(session.getCounselId()),
       userId: new UniqueEntityId(session.getUserId()),
       counselTechniqueId: new UniqueEntityId(session.getCurrentTechniqueId()),
       message: aiResponse,
     });
+    session = session.withNewMessage(createdAssistantMessage);
 
     // 8. 상담 정보 업데이트 (마지막 메시지)
     const updatedCounsel = await this.messageManager.updateLastMessage({
       counselId: new UniqueEntityId(session.getCounselId()),
-      lastMessage: createdSystemMessage.message,
+      lastMessage: createdAssistantMessage.message,
     });
+
+    // 9. 백그라운드에서 기법 전환 평가 수행
+    this.evaluateTechniqueTransitionInBackground(session);
 
     return {
       counsel: updatedCounsel,
       createdCounselMessage: createdUserMessage,
-      counselorResponseMessage: createdSystemMessage,
+      counselorResponseMessage: createdAssistantMessage,
     };
   }
 
   /**
-   * 상담 세션 컨텍스트 구성
-   * @param counselId 상담 ID
-   * @returns 구성된 CounselSession 인스턴스
+   * 백그라운드에서 기법 전환 평가 및 실행
+   * @param session 상담 세션
+   * @param latestMessage 최신 메시지
    */
-  private async buildCounselSession(counselId: UniqueEntityId): Promise<CounselSession> {
-    // 병렬로 데이터 수집
-    const [counsel, counselMessages] = await Promise.all([
-      this.counselService.getOne({ counselId }),
-      this.messageManager.getCounselMessages(counselId),
-    ]);
+  private evaluateTechniqueTransitionInBackground(session: CounselSession): void {
+    // 백그라운드 처리를 위해 Promise.resolve()를 사용
+    Promise.resolve()
+      .then(async () => {
+        // 1. TechniqueManager에서 평가 준비 (도메인 로직만 사용)
+        const preparationResult = await this.techniqueManager.prepareBackgroundEvaluation({
+          counsel: session.getCounsel(),
+          messages: session.getMessages(),
+        });
 
-    const [counselor, promptVersion, currentTechnique] = await Promise.all([
-      this.counselorService.getOne({ counselorId: new UniqueEntityId(counsel.counselorId) }),
-      this.promptVersionsService.getOne({ promptVersionId: new UniqueEntityId(counsel.promptVersionId) }),
-      this.counselTechniqueService.getOne({ counselTechniqueId: new UniqueEntityId(counsel.counselTechniqueId) }),
-    ]);
+        // 평가가 불필요한 경우
+        if (!preparationResult.shouldEvaluate) {
+          this.logger.log(
+            `Technique evaluation skipped for counsel ${session.getCounselId()}: ${preparationResult.reason}`,
+          );
+          return;
+        }
 
-    return new CounselSession({
-      counsel,
-      counselor,
-      messages: counselMessages,
-      promptVersion,
-      currentTechnique,
+        // 2. AI 평가 수행
+        const decision = await this.performAIEvaluation(preparationResult.evaluationRequest);
+
+        // 3. TechniqueManager에서 평가 결과 처리
+        const evaluationResult = await this.techniqueManager.processEvaluationResult(session.getCounselId(), decision);
+
+        // 로깅
+        if (evaluationResult.evaluationPerformed && decision.shouldTransition) {
+          this.logger.log(`Technique transition executed for counsel ${session.getCounselId()}`, {
+            currentTechniqueId: session.getCurrentTechniqueId(),
+            scores: decision.scores,
+            confidence: decision.confidence,
+          });
+        } else if (evaluationResult.evaluationPerformed) {
+          this.logger.log(`Technique transition not recommended for counsel ${session.getCounselId()}`, {
+            currentTechniqueId: session.getCurrentTechniqueId(),
+            scores: decision.scores,
+            confidence: decision.confidence,
+          });
+        }
+      })
+      .catch((error) => {
+        this.logger.error(`Error in background technique evaluation for counsel ${session.getCounselId()}`, error);
+      });
+  }
+
+  /**
+   * AI 평가 수행 (support 서비스들 활용)
+   * @param request 평가 요청
+   * @returns 기법 전환 결정
+   */
+  private async performAIEvaluation(request: TechniqueEvaluationRequest): Promise<TechniqueTransitionDecision> {
+    // 현재 기법 메시지들을 대화 히스토리로 구성
+    const conversationHistory = this.historyBuilder.buildHistory(request.currentTechniqueMessages);
+    // 기법 평가용 통합 시스템 프롬프트 생성
+    const systemPrompt = this.promptBuilder.buildTechniqueEvaluationSystemPrompt({
+      currentTechnique: request.currentTechnique,
+      nextTechnique: request.nextTechnique,
+      messageThreshold: request.messageThreshold,
     });
+
+    // 간단한 평가 요청 메시지
+    const evaluationRequest = `현재 기법에서 다음 기법으로 전환해야 하는지 평가해주세요. 
+현재 기법으로 진행된 메시지 수: ${request.currentTechniqueMessages.length}개`;
+
+    // AI 평가 수행
+    const aiResponse = await this.aiGenerator.generateResponse(
+      systemPrompt,
+      conversationHistory,
+      evaluationRequest,
+      `technique-evaluation-${Date.now()}`,
+    );
+    // 파서를 사용하여 응답 파싱
+    return this.techniqueEvaluationParser.parseTechniqueEvaluationResponse(aiResponse);
   }
 }

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -145,7 +145,11 @@ export class CounselingOrchestrator {
         const decision = await this.performAIEvaluation(preparationResult.evaluationRequest);
 
         // 3. TechniqueManager에서 평가 결과 처리
-        const evaluationResult = await this.techniqueManager.processEvaluationResult(session.getCounselId(), decision);
+        const evaluationResult = await this.techniqueManager.processEvaluationResult(
+          preparationResult.evaluationRequest,
+          session,
+          decision,
+        );
 
         // 로깅
         if (evaluationResult.evaluationPerformed && decision.shouldTransition) {

--- a/src/services/counselings/applications/counsel-managements/support/ai-response.generator.ts
+++ b/src/services/counselings/applications/counsel-managements/support/ai-response.generator.ts
@@ -55,8 +55,10 @@ export class AIResponseGenerator {
     const fullMessage = `
 <ConversationHistory>
 ${conversationHistory ? conversationHistory : "none"}
+</ConversationHistory>
 <CurrentUserMessage>
 ${userMessage}
+</CurrentUserMessage>
 `;
 
     return {

--- a/src/services/counselings/applications/counsel-managements/support/context.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/context.manager.ts
@@ -1,0 +1,42 @@
+import { CounselSession } from "~counselings/applications/counsel-managements/models/counsel-session";
+import { CounselMessagesService } from "~counselings/domains/counselMessages/counselMessages.service";
+import { CounselorsService } from "~counselings/domains/counselors/counselors.service";
+import { CounselsService } from "~counselings/domains/counsels/counsels.service";
+import { CounselTechniquesService } from "~counselings/domains/counselTechniques/counselTechniques.service";
+import { PromptVersionsService } from "~counselings/domains/promptVersions/promptVersions.service";
+
+import { Injectable } from "@nestjs/common";
+import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
+
+@Injectable()
+export class ContextManager {
+  constructor(
+    private readonly counselService: CounselsService,
+    private readonly counselMessageService: CounselMessagesService,
+    private readonly counselorService: CounselorsService,
+    private readonly promptVersionsService: PromptVersionsService,
+    private readonly counselTechniqueService: CounselTechniquesService,
+  ) {}
+
+  async buildCounselSession(counselId: UniqueEntityId): Promise<CounselSession> {
+    // 병렬로 데이터 수집
+    const [counsel, counselMessages] = await Promise.all([
+      this.counselService.getOne({ counselId }),
+      this.counselMessageService.getMany({ counselId }),
+    ]);
+
+    const [counselor, promptVersion, currentTechnique] = await Promise.all([
+      this.counselorService.getOne({ counselorId: new UniqueEntityId(counsel.counselorId) }),
+      this.promptVersionsService.getOne({ promptVersionId: new UniqueEntityId(counsel.promptVersionId) }),
+      this.counselTechniqueService.getOne({ counselTechniqueId: new UniqueEntityId(counsel.counselTechniqueId) }),
+    ]);
+
+    return new CounselSession({
+      counsel,
+      counselor,
+      messages: counselMessages,
+      promptVersion,
+      currentTechnique,
+    });
+  }
+}

--- a/src/services/counselings/applications/counsel-managements/support/message.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/message.manager.ts
@@ -1,5 +1,5 @@
 import {
-  CreateSystemMessageParams,
+  CreateAssistantMessageParams,
   CreateUserMessageParams,
   UpdateLastMessageParams,
 } from "~counselings/applications/counsel-managements/types/message.type";
@@ -9,7 +9,6 @@ import { CounselsService } from "~counselings/domains/counsels/counsels.service"
 import { CounselInfo } from "~counselings/domains/counsels/models/counsel.info";
 
 import { Injectable } from "@nestjs/common";
-import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
 
 /**
  * 메시지 생성/저장을 담당하는 서비스
@@ -38,11 +37,11 @@ export class MessageManager {
   }
 
   /**
-   * 시스템(AI) 메시지 생성
-   * @param params 시스템 메시지 생성 파라미터
-   * @returns 생성된 시스템 메시지
+   * 어시스턴트(AI) 메시지 생성
+   * @param params 어시스턴트 메시지 생성 파라미터
+   * @returns 생성된 어시스턴트 메시지
    */
-  async createSystemMessage(params: CreateSystemMessageParams): Promise<CounselMessageInfo> {
+  async createAssistantMessage(params: CreateAssistantMessageParams): Promise<CounselMessageInfo> {
     return this.counselMessageService.create({
       counselId: params.counselId,
       userId: params.userId,
@@ -62,14 +61,5 @@ export class MessageManager {
       counselId: params.counselId,
       lastMessage: params.lastMessage,
     });
-  }
-
-  /**
-   * 특정 상담의 모든 메시지 조회
-   * @param counselId 상담 ID
-   * @returns 메시지 배열
-   */
-  async getCounselMessages(counselId: UniqueEntityId): Promise<CounselMessageInfo[]> {
-    return this.counselMessageService.getMany({ counselId });
   }
 }

--- a/src/services/counselings/applications/counsel-managements/support/system-prompt.builder.ts
+++ b/src/services/counselings/applications/counsel-managements/support/system-prompt.builder.ts
@@ -11,6 +11,12 @@ export interface SystemPromptBuildParams {
   counselTechnique: CounselTechniqueInfo;
 }
 
+export interface TechniqueEvaluationSystemPromptParams {
+  currentTechnique: CounselTechniqueInfo;
+  nextTechnique: CounselTechniqueInfo;
+  messageThreshold: number;
+}
+
 /**
  * 시스템 프롬프트 생성을 담당하는 서비스
  * 단일 책임: 다양한 프롬프트 구성 요소를 조합하여 최종 시스템 프롬프트 생성
@@ -45,13 +51,74 @@ export class SystemPromptBuilder {
     const systemPrompt = `
 <Persona>
 ${persona}
+</Persona>
 <Context>
 ${context}
+</Context>
 <Instruction>
 ${instruction}
+</Instruction>
 <Tone>
 ${tone}
+</Tone>
 `;
     return systemPrompt;
+  }
+
+  /**
+   * 기법 전환 평가용 통합 시스템 프롬프트 생성
+   * @param params 평가 시스템 프롬프트 파라미터
+   * @returns 완성된 평가 시스템 프롬프트
+   */
+  buildTechniqueEvaluationSystemPrompt(params: TechniqueEvaluationSystemPromptParams): string {
+    const { currentTechnique, nextTechnique, messageThreshold } = params;
+
+    return `
+당신은 상담 기법 전환을 평가하는 전문가입니다.
+상담 대화의 흐름과 현재 기법의 효과를 분석하여 다음 기법으로 전환할 적절한 시점을 판단합니다.
+
+<CurrentTechnique>
+Name: ${currentTechnique.name}
+Context: ${currentTechnique.context}
+Instruction: ${currentTechnique.instruction}
+MessageThreshold: ${currentTechnique.messageThreshold}
+</CurrentTechnique>
+
+<NextTechnique>
+Name: ${nextTechnique.name}
+Context: ${nextTechnique.context}
+Instruction: ${nextTechnique.instruction}
+</NextTechnique>
+
+<EvaluationCriteria>
+다음 기준들을 고려하여 각각 0-100점으로 점수를 매기고, 전환 여부를 결정해주세요:
+
+1. conversationProgressScore: 대화가 충분히 진행되었는가?
+2. userEngagementScore: 사용자가 충분히 참여하고 있는가?
+3. goalAchievementScore: 현재 기법의 목표가 어느 정도 달성되었는가?
+4. appropriatenessScore: 다음 기법으로 전환하는 것이 적절한가?
+
+현재 기법의 메시지 임계값: ${messageThreshold}
+</EvaluationCriteria>
+
+<ResponseFormat>
+반드시 다음 JSON 형태로 응답해주세요:
+{
+  "shouldTransition": boolean,
+  "scores": {
+    "conversationProgressScore": number,
+    "userEngagementScore": number,
+    "goalAchievementScore": number,
+    "appropriatenessScore": number,
+    "overallScore": number,
+    "reasoning": "판별 근거"
+  },
+  "confidence": number
+}
+
+overallScore는 모든 점수의 가중평균으로, shouldTransition은 overallScore가 70점 이상일 때 true로 설정하되, 
+전체적인 상황을 고려하여 유연하게 판단하세요.
+</ResponseFormat>
+`;
   }
 }

--- a/src/services/counselings/applications/counsel-managements/support/technique-evaluation.parser.ts
+++ b/src/services/counselings/applications/counsel-managements/support/technique-evaluation.parser.ts
@@ -1,0 +1,71 @@
+import {
+  TechniqueTransitionDecision,
+  TechniqueTransitionScore,
+} from "~counselings/applications/counsel-managements/types/technique.type";
+
+import { Injectable } from "@nestjs/common";
+
+/**
+ * 기법 전환 평가 응답 파싱을 담당하는 서비스
+ * 단일 책임: AI 응답의 파싱과 검증
+ */
+@Injectable()
+export class TechniqueEvaluationParser {
+  /**
+   * AI 응답 파싱
+   * @param response AI 응답 텍스트
+   * @returns 파싱된 기법 전환 결정
+   */
+  parseTechniqueEvaluationResponse(response: string): TechniqueTransitionDecision {
+    try {
+      // JSON 부분만 추출
+      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error("No JSON found in response");
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]);
+
+      // 기본값 설정 및 검증
+      const scores: TechniqueTransitionScore = {
+        conversationProgressScore: this.validateScore(parsed.scores?.conversationProgressScore),
+        userEngagementScore: this.validateScore(parsed.scores?.userEngagementScore),
+        goalAchievementScore: this.validateScore(parsed.scores?.goalAchievementScore),
+        appropriatenessScore: this.validateScore(parsed.scores?.appropriatenessScore),
+        overallScore: this.validateScore(parsed.scores?.overallScore),
+        reasoning: parsed.scores?.reasoning || "No reasoning provided",
+      };
+
+      return {
+        shouldTransition: Boolean(parsed.shouldTransition),
+        scores,
+        confidence: this.validateScore(parsed.confidence),
+      };
+    } catch (error) {
+      // 파싱 실패 시 기본값 반환
+      return {
+        shouldTransition: false,
+        scores: {
+          conversationProgressScore: 0,
+          userEngagementScore: 0,
+          goalAchievementScore: 0,
+          appropriatenessScore: 0,
+          overallScore: 0,
+          reasoning: `Parsing failed: ${error.message}`,
+        },
+        confidence: 0,
+      };
+    }
+  }
+
+  /**
+   * 점수 검증 (0-100 범위)
+   * @param score 점수
+   * @returns 검증된 점수
+   */
+  private validateScore(score: any): number {
+    const numScore = Number(score);
+    if (isNaN(numScore)) return 0;
+    return Math.max(0, Math.min(100, numScore));
+  }
+}

--- a/src/services/counselings/applications/counsel-managements/support/technique.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/technique.manager.ts
@@ -1,3 +1,4 @@
+import { CounselSession } from "~counselings/applications/counsel-managements/models/counsel-session";
 import {
   BackgroundTechniqueEvaluationResult,
   TechniqueTransitionDecision,
@@ -128,12 +129,16 @@ export class TechniqueManager {
    * @returns 백그라운드 평가 결과
    */
   async processEvaluationResult(
-    counselId: string,
+    techniqueEvaluationRequest: TechniqueEvaluationRequest,
+    session: CounselSession,
     decision: TechniqueTransitionDecision,
   ): Promise<BackgroundTechniqueEvaluationResult> {
     try {
       if (decision.shouldTransition) {
-        await this.executeTechniqueTransition(counselId, decision);
+        await this.counselService.updateCounselTechniqueId({
+          counselId: new UniqueEntityId(session.getCounselId()),
+          counselTechniqueId: new UniqueEntityId(techniqueEvaluationRequest.nextTechnique.id),
+        });
       }
 
       return {
@@ -146,38 +151,6 @@ export class TechniqueManager {
         error: error.message,
       };
     }
-  }
-
-  /**
-   * AI 평가 결과에 따른 기법 전환 실행
-   * @param counselId 상담 ID
-   * @param decision AI 평가 결과
-   * @returns 업데이트된 상담 정보
-   */
-  async executeTechniqueTransition(counselId: string, decision: TechniqueTransitionDecision): Promise<CounselInfo> {
-    if (!decision.shouldTransition) {
-      throw new Error("Transition decision is false");
-    }
-
-    // 현재 상담 정보 조회
-    const counsel = await this.counselService.getOne({
-      counselId: new UniqueEntityId(counselId),
-    });
-
-    // 현재 기법 조회
-    const currentTechnique = await this.counselTechniqueService.getOne({
-      counselTechniqueId: new UniqueEntityId(counsel.counselTechniqueId),
-    });
-
-    if (!currentTechnique.nextTechniqueId) {
-      throw new Error("No next technique available");
-    }
-
-    // 기법 전환 실행
-    return this.counselService.updateCounselTechniqueId({
-      counselId: new UniqueEntityId(counselId),
-      counselTechniqueId: new UniqueEntityId(currentTechnique.nextTechniqueId),
-    });
   }
 
   /**

--- a/src/services/counselings/applications/counsel-managements/support/technique.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/technique.manager.ts
@@ -1,7 +1,6 @@
 import {
-  TechniqueChangeCheckParams,
-  TechniqueResetCheckParams,
-  TechniqueUpdateParams,
+  BackgroundTechniqueEvaluationResult,
+  TechniqueTransitionDecision,
 } from "~counselings/applications/counsel-managements/types/technique.type";
 import { CounselMessageInfo } from "~counselings/domains/counselMessages/models/counselMessage.info";
 import { CounselsService } from "~counselings/domains/counsels/counsels.service";
@@ -10,26 +9,28 @@ import { CounselTechniquesService } from "~counselings/domains/counselTechniques
 import { CounselTechniqueInfo } from "~counselings/domains/counselTechniques/models/counselTechnique.info";
 
 import { Injectable } from "@nestjs/common";
-import { getNowDayjs } from "~common/shared/utils/date";
 import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
-import { Dayjs } from "dayjs";
 
 export interface TechniqueManagementParams {
   counsel: CounselInfo;
   messages: CounselMessageInfo[];
-  firstCounselTechniqueId: string;
-  timeDurationForReset: number;
 }
 
 export interface TechniqueManagementResult {
   counsel: CounselInfo;
   currentTechnique: CounselTechniqueInfo;
-  hasChanged: boolean;
+}
+
+export interface TechniqueEvaluationRequest {
+  currentTechnique: CounselTechniqueInfo;
+  nextTechnique: CounselTechniqueInfo;
+  currentTechniqueMessages: CounselMessageInfo[];
+  messageThreshold: number;
 }
 
 /**
  * 상담기법 관리를 담당하는 서비스
- * 단일 책임: 상담기법의 초기화, 변경, 전환 로직만 담당
+ * 단일 책임: 상담기법의 조회, 평가 로직, 전환 실행 담당 (도메인 서비스만 사용)
  */
 @Injectable()
 export class TechniqueManager {
@@ -39,144 +40,177 @@ export class TechniqueManager {
   ) {}
 
   /**
-   * 상담기법 전체 관리 (초기화 + 변경 체크)
+   * 상담기법 조회
    * @param params 기법 관리 파라미터
-   * @returns 관리 결과 (상담 정보, 현재 기법, 변경 여부)
+   * @returns 관리 결과 (상담 정보, 현재 기법)
    */
-  async manageTechnique(params: TechniqueManagementParams): Promise<TechniqueManagementResult> {
-    let { counsel } = params;
-    let hasChanged = false;
+  async getCurrentTechnique(params: TechniqueManagementParams): Promise<TechniqueManagementResult> {
+    const { counsel } = params;
 
-    // 1. 시간 기반 초기화 체크
-    const shouldReset = this.shouldResetTechnique({
-      lastMessageTime: this.getLastMessageTime(params.messages),
-      timeDurationForReset: params.timeDurationForReset,
-    });
-
-    if (shouldReset) {
-      counsel = await this.resetToFirstTechnique(counsel, params.firstCounselTechniqueId);
-      hasChanged = true;
-    }
-
-    // 2. 현재 상담기법 조회
-    let currentTechnique = await this.counselTechniqueService.getOne({
+    // 현재 상담기법 조회
+    const currentTechnique = await this.counselTechniqueService.getOne({
       counselTechniqueId: new UniqueEntityId(counsel.counselTechniqueId),
     });
-
-    // 3. 메시지 수 기반 변경 체크
-    const shouldChange = this.shouldChangeTechnique({
-      messages: params.messages,
-      currentTechniqueId: counsel.counselTechniqueId,
-      messageThreshold: currentTechnique.messageThreshold,
-    });
-
-    if (shouldChange && currentTechnique.nextTechniqueId) {
-      const nextTechnique = await this.counselTechniqueService.getOne({
-        counselTechniqueId: new UniqueEntityId(currentTechnique.nextTechniqueId),
-      });
-
-      counsel = await this.updateCounselTechnique({
-        counselId: new UniqueEntityId(counsel.id),
-        newTechniqueId: new UniqueEntityId(nextTechnique.id),
-      });
-
-      currentTechnique = nextTechnique;
-      hasChanged = true;
-    }
 
     return {
       counsel,
       currentTechnique,
-      hasChanged,
     };
   }
 
   /**
-   * 시간 기반 상담기법 초기화 여부 확인
-   * @param params 초기화 체크 파라미터
-   * @returns 초기화 필요 여부
+   * 백그라운드 기법 전환 평가 준비 (AI 평가 제외)
+   * @param params 기법 관리 파라미터
+   * @returns 평가 요청 또는 평가 불필요 결과
    */
-  private shouldResetTechnique(params: TechniqueResetCheckParams): boolean {
-    const now = getNowDayjs();
-    const timeDiff = now.diff(params.lastMessageTime);
-    return timeDiff > params.timeDurationForReset;
+  async prepareBackgroundEvaluation(
+    params: TechniqueManagementParams,
+  ): Promise<
+    { shouldEvaluate: false; reason: string } | { shouldEvaluate: true; evaluationRequest: TechniqueEvaluationRequest }
+  > {
+    try {
+      // 현재 기법 조회
+      const currentTechnique = await this.counselTechniqueService.getOne({
+        counselTechniqueId: new UniqueEntityId(params.counsel.counselTechniqueId),
+      });
+
+      // 다음 기법이 없으면 평가하지 않음
+      if (!currentTechnique.nextTechniqueId) {
+        return {
+          shouldEvaluate: false,
+          reason: "No next technique available",
+        };
+      }
+
+      // 메시지 수 기반 기본 조건 확인
+      const currentTechniqueMessages = this.getCurrentTechniqueMessages(
+        params.messages,
+        params.counsel.counselTechniqueId,
+      );
+
+      const userMessageCount = this.countUserMessagesFromMessages(currentTechniqueMessages);
+
+      // 임계값 이상 메시지가 있어야 AI 평가 수행
+      if (userMessageCount < currentTechnique.messageThreshold) {
+        return {
+          shouldEvaluate: false,
+          reason: `Insufficient messages: ${userMessageCount}/${currentTechnique.messageThreshold}`,
+        };
+      }
+
+      // 다음 기법 조회
+      const nextTechnique = await this.counselTechniqueService.getOne({
+        counselTechniqueId: new UniqueEntityId(currentTechnique.nextTechniqueId),
+      });
+
+      // AI 평가 요청 준비
+      return {
+        shouldEvaluate: true,
+        evaluationRequest: {
+          currentTechnique,
+          nextTechnique,
+          currentTechniqueMessages,
+          messageThreshold: currentTechnique.messageThreshold,
+        },
+      };
+    } catch (error) {
+      return {
+        shouldEvaluate: false,
+        reason: `Error during preparation: ${error.message}`,
+      };
+    }
   }
 
   /**
-   * 메시지 수 기반 상담기법 변경 여부 확인
-   * @param params 변경 체크 파라미터
-   * @returns 변경 필요 여부
+   * AI 평가 결과에 따른 기법 전환 처리
+   * @param counselId 상담 ID
+   * @param decision AI 평가 결과
+   * @returns 백그라운드 평가 결과
    */
-  private shouldChangeTechnique(params: TechniqueChangeCheckParams): boolean {
-    const messageCountAtCurrentTechnique = this.countMessagesForCurrentTechnique(
-      params.messages,
-      params.currentTechniqueId,
-    );
+  async processEvaluationResult(
+    counselId: string,
+    decision: TechniqueTransitionDecision,
+  ): Promise<BackgroundTechniqueEvaluationResult> {
+    try {
+      if (decision.shouldTransition) {
+        await this.executeTechniqueTransition(counselId, decision);
+      }
 
-    return messageCountAtCurrentTechnique >= params.messageThreshold;
+      return {
+        evaluationPerformed: true,
+        decision,
+      };
+    } catch (error) {
+      return {
+        evaluationPerformed: false,
+        error: error.message,
+      };
+    }
   }
 
   /**
-   * 현재 상담기법에서의 유저 메시지 수 계산
-   * @param messages 메시지 배열
-   * @param currentTechniqueId 현재 상담기법 ID
-   * @returns 메시지 수
+   * AI 평가 결과에 따른 기법 전환 실행
+   * @param counselId 상담 ID
+   * @param decision AI 평가 결과
+   * @returns 업데이트된 상담 정보
    */
-  private countMessagesForCurrentTechnique(messages: CounselMessageInfo[], currentTechniqueId: string): number {
-    let count = 0;
+  async executeTechniqueTransition(counselId: string, decision: TechniqueTransitionDecision): Promise<CounselInfo> {
+    if (!decision.shouldTransition) {
+      throw new Error("Transition decision is false");
+    }
+
+    // 현재 상담 정보 조회
+    const counsel = await this.counselService.getOne({
+      counselId: new UniqueEntityId(counselId),
+    });
+
+    // 현재 기법 조회
+    const currentTechnique = await this.counselTechniqueService.getOne({
+      counselTechniqueId: new UniqueEntityId(counsel.counselTechniqueId),
+    });
+
+    if (!currentTechnique.nextTechniqueId) {
+      throw new Error("No next technique available");
+    }
+
+    // 기법 전환 실행
+    return this.counselService.updateCounselTechniqueId({
+      counselId: new UniqueEntityId(counselId),
+      counselTechniqueId: new UniqueEntityId(currentTechnique.nextTechniqueId),
+    });
+  }
+
+  /**
+   * 현재 기법으로 진행된 메시지들만 추출
+   * @param messages 전체 메시지 배열
+   * @param currentTechniqueId 현재 기법 ID
+   * @returns 현재 기법 메시지들
+   */
+  private getCurrentTechniqueMessages(
+    messages: CounselMessageInfo[],
+    currentTechniqueId: string,
+  ): CounselMessageInfo[] {
+    const currentTechniqueMessages = [];
 
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
-
-      if (!message.isUserMessage) {
-        continue;
-      }
 
       if (message.counselTechniqueId !== currentTechniqueId) {
         break;
       }
 
-      count++;
+      currentTechniqueMessages.unshift(message);
     }
 
-    return count;
+    return currentTechniqueMessages;
   }
 
   /**
-   * 첫 번째 상담기법으로 초기화
-   * @param counsel 상담 정보
-   * @param firstTechniqueId 첫 번째 상담기법 ID
-   * @returns 업데이트된 상담 정보
-   */
-  private async resetToFirstTechnique(counsel: CounselInfo, firstTechniqueId: string): Promise<CounselInfo> {
-    return this.counselService.updateCounselTechniqueId({
-      counselId: new UniqueEntityId(counsel.id),
-      counselTechniqueId: new UniqueEntityId(firstTechniqueId),
-    });
-  }
-
-  /**
-   * 상담기법 업데이트
-   * @param params 업데이트 파라미터
-   * @returns 업데이트된 상담 정보
-   */
-  private async updateCounselTechnique(params: TechniqueUpdateParams): Promise<CounselInfo> {
-    return this.counselService.updateCounselTechniqueId({
-      counselId: params.counselId,
-      counselTechniqueId: params.newTechniqueId,
-    });
-  }
-
-  /**
-   * 마지막 메시지 시간 추출
+   * 메시지 배열에서 유저 메시지 수 계산
    * @param messages 메시지 배열
-   * @returns 마지막 메시지 시간
+   * @returns 유저 메시지 수
    */
-  private getLastMessageTime(messages: CounselMessageInfo[]): Dayjs {
-    if (messages.length === 0) {
-      return getNowDayjs(); // 메시지가 없으면 현재 시간 반환
-    }
-
-    return messages[messages.length - 1].createdAt;
+  private countUserMessagesFromMessages(messages: CounselMessageInfo[]): number {
+    return messages.filter((msg) => msg.isUserMessage).length;
   }
 }

--- a/src/services/counselings/applications/counsel-managements/types/message.type.ts
+++ b/src/services/counselings/applications/counsel-managements/types/message.type.ts
@@ -7,7 +7,7 @@ export type CreateUserMessageParams = {
   message: string;
 };
 
-export type CreateSystemMessageParams = {
+export type CreateAssistantMessageParams = {
   counselId: UniqueEntityId;
   userId: UniqueEntityId;
   counselTechniqueId: UniqueEntityId;

--- a/src/services/counselings/applications/counsel-managements/types/technique.type.ts
+++ b/src/services/counselings/applications/counsel-managements/types/technique.type.ts
@@ -1,26 +1,30 @@
 import { CounselMessageInfo } from "~counselings/domains/counselMessages/models/counselMessage.info";
 
-import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
-import { Dayjs } from "dayjs";
-
-export type TechniqueResetCheckParams = {
-  lastMessageTime: Dayjs;
-  timeDurationForReset: number;
-};
-
-export type TechniqueChangeCheckParams = {
-  messages: CounselMessageInfo[];
+export type TechniqueTransitionEvaluationParams = {
   currentTechniqueId: string;
+  nextTechniqueId: string;
+  messages: CounselMessageInfo[];
   messageThreshold: number;
 };
 
-export type TechniqueUpdateParams = {
-  counselId: UniqueEntityId;
-  newTechniqueId: UniqueEntityId;
+export type TechniqueTransitionScore = {
+  conversationProgressScore: number; // 대화 진행도 점수 (0-100)
+  userEngagementScore: number; // 사용자 참여도 점수 (0-100)
+  goalAchievementScore: number; // 목표 달성도 점수 (0-100)
+  appropriatenessScore: number; // 다음 기법 적절성 점수 (0-100)
+  overallScore: number; // 전체 점수 (0-100)
+  reasoning: string; // 판별 근거
 };
 
-export type TechniqueManagementResult = {
-  shouldReset: boolean;
-  shouldChange: boolean;
-  nextTechniqueId?: UniqueEntityId;
+export type TechniqueTransitionDecision = {
+  shouldTransition: boolean;
+  scores: TechniqueTransitionScore;
+  confidence: number; // 신뢰도 (0-100)
+};
+
+// 백그라운드 기법 전환 평가 결과
+export type BackgroundTechniqueEvaluationResult = {
+  evaluationPerformed: boolean;
+  decision?: TechniqueTransitionDecision;
+  error?: string;
 };

--- a/src/services/counselings/domains/counsels/counsels.service.ts
+++ b/src/services/counselings/domains/counsels/counsels.service.ts
@@ -45,6 +45,9 @@ export class CounselsService {
     if (!counsel) {
       throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
     }
+    if (counsel.counselTechniqueId.equals(counselTechniqueId)) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_ACCEPTABLE, "Counsel technique id is already updated");
+    }
 
     counsel.updateCounselTechniqueId(counselTechniqueId);
 


### PR DESCRIPTION
상담 테크닉 평가  기능을 구현했습니다.
임계점을 넘겼을 때 기준으로

## 시스템 프롬프트
<img width="969" alt="image" src="https://github.com/user-attachments/assets/daa7cc29-9008-4cb8-8e24-d6551ff5c357" />

## 유저 프롬프트
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/ff9ca477-3b58-4de4-ae7e-d2d00920789e" />

## 결과
<img width="1025" alt="image" src="https://github.com/user-attachments/assets/d5073558-b7b7-4f9d-826f-39426515c70c" />

위와 같은 프로세스로 다음 테크닉으로 갈 지를 결정합니다.
결정 시기는 최종 ai 응답이 return된 이후입니다.
응답이 완료된 후 await 없이 백그라운드에서 실행됩니다.