### PR TITLE
기존 버전 로드 로직 500 에러 수정

### DIFF
--- a/src/services/counselings/domains/promptVersions/infrastructures/psql-promptVersions.repository.ts
+++ b/src/services/counselings/domains/promptVersions/infrastructures/psql-promptVersions.repository.ts
@@ -48,10 +48,16 @@ export class PsqlPromptVersionsRepository extends PromptVersionsRepository {
   async save(promptVersion: PromptVersions | PromptVersions[]): Promise<PromptVersions | PromptVersions[]> {
     if (Array.isArray(promptVersion)) {
       await this.promptVersionsRepository.save(PsqlPromptVersionsMapper.toEntities(promptVersion));
+
+      promptVersion.forEach((pv) => {
+        pv.removeDeletedRelations();
+      });
       return promptVersion;
     } else {
       const promptVersionEntity = PsqlPromptVersionsMapper.toEntity(promptVersion);
       await this.promptVersionsRepository.save(promptVersionEntity);
+
+      promptVersion.removeDeletedRelations();
       return promptVersion;
     }
   }

--- a/src/services/counselings/domains/promptVersions/infrastructures/psql-promptVersions.repository.ts
+++ b/src/services/counselings/domains/promptVersions/infrastructures/psql-promptVersions.repository.ts
@@ -49,15 +49,11 @@ export class PsqlPromptVersionsRepository extends PromptVersionsRepository {
     if (Array.isArray(promptVersion)) {
       await this.promptVersionsRepository.save(PsqlPromptVersionsMapper.toEntities(promptVersion));
 
-      promptVersion.forEach((pv) => {
-        pv.removeDeletedRelations();
-      });
       return promptVersion;
     } else {
       const promptVersionEntity = PsqlPromptVersionsMapper.toEntity(promptVersion);
       await this.promptVersionsRepository.save(promptVersionEntity);
 
-      promptVersion.removeDeletedRelations();
       return promptVersion;
     }
   }

--- a/src/services/counselings/domains/promptVersions/models/promptVersions.ts
+++ b/src/services/counselings/domains/promptVersions/models/promptVersions.ts
@@ -338,13 +338,28 @@ export class PromptVersions extends AggregateRoot<PromptVersionsProps> {
   }
 
   public clonePrompts(promptVersion: PromptVersions): Result<void> {
+    if (!this.props.isTemporary) {
+      return Result.fail<void>("[PromptVersions] Only temporary PromptVersion can clone prompts.");
+    }
+    if (this.props.isActive) {
+      return Result.fail<void>("[PromptVersions] Active PromptVersion cannot clone prompts.");
+    }
+    if (promptVersion.isTemporary) {
+      return Result.fail<void>("[PromptVersions] Cannot clone from a temporary PromptVersion.");
+    }
+
     this.props.isTemporary = true;
     this.props.isActive = false;
     this.props.name = "Temporary name";
     this.props.description = "Temporary description";
-    this.props.counselorScopedPrompts = [];
-    this.props.toneScopedPrompts = [];
     this.props.updatedAt = getNowDayjs();
+
+    for (const existingCounselorScopedPrompt of this.props.counselorScopedPrompts) {
+      existingCounselorScopedPrompt.delete();
+    }
+    for (const existingToneScopedPrompt of this.props.toneScopedPrompts) {
+      existingToneScopedPrompt.delete();
+    }
 
     for (const counselorScopedPrompt of promptVersion.counselorScopedPrompts) {
       const clonedCounselorScopedPrompt = CounselorScopedPrompts.createNew({
@@ -372,6 +387,11 @@ export class PromptVersions extends AggregateRoot<PromptVersionsProps> {
     }
 
     return Result.ok();
+  }
+
+  public removeDeletedRelations(): void {
+    this.props.counselorScopedPrompts = this.props.counselorScopedPrompts.filter((prompt) => prompt.deletedAt === null);
+    this.props.toneScopedPrompts = this.props.toneScopedPrompts.filter((prompt) => prompt.deletedAt === null);
   }
 
   public updateBasicInfo(props: {

--- a/src/services/counselings/domains/promptVersions/models/promptVersions.ts
+++ b/src/services/counselings/domains/promptVersions/models/promptVersions.ts
@@ -389,11 +389,6 @@ export class PromptVersions extends AggregateRoot<PromptVersionsProps> {
     return Result.ok();
   }
 
-  public removeDeletedRelations(): void {
-    this.props.counselorScopedPrompts = this.props.counselorScopedPrompts.filter((prompt) => prompt.deletedAt === null);
-    this.props.toneScopedPrompts = this.props.toneScopedPrompts.filter((prompt) => prompt.deletedAt === null);
-  }
-
   public updateBasicInfo(props: {
     name?: string;
     description?: string;


### PR DESCRIPTION
기존 버전을 임시버전으로 불러오는 과정에서 임시버전에 남아있는 데이터들을 새로운 데이터로 대체합니다.
이때 남아있는 데이터들을 단순히 제외만 하였더니 FK 를 null 로 업데이트하려다 에러가 발생했네요.
명시적으로 delete() 호출하여 삭제처리하였습니다.

추가로 삭제한 데이터는 응답으로 가지 않도록 repository 단계에서 삭제된 관계 정리하는 로직을 추가하였습니다.
-> 이거는 repository 가 영속화 및 후처리 책임을 갖는다고 판단해서 이렇게 하긴 했는데 persister에서 할지, mapper 에서 제외를 할지 등 살짝 이야기해봐도 좋을 거 같아요.
삭제된 데이터를 반환할 일이 없다면 서버 전반적으로 적용해도 되지 않을까..!