### PR TITLE
Fix/find deleted

### DIFF
--- a/src/services/counselings/applications/counsel-prompt-managements/counsel-prompt-managements.facade.ts
+++ b/src/services/counselings/applications/counsel-prompt-managements/counsel-prompt-managements.facade.ts
@@ -44,7 +44,7 @@ export class CounselPromptManagementsFacade {
 
   async findPromptVersionById(param: { promptVersionId: UniqueEntityId }): Promise<PromptVersionInfo> {
     const { promptVersionId } = param;
-    return this.promptVersionService.getOne({ promptVersionId });
+    return this.promptVersionService.getOne({ promptVersionId, withDeleted: true });
   }
 
   // 내부적으로 생성로직 포함

--- a/src/services/counselings/domains/promptVersions/infrastructures/mappers/repository-promptVersions-criteria.mapper.ts
+++ b/src/services/counselings/domains/promptVersions/infrastructures/mappers/repository-promptVersions-criteria.mapper.ts
@@ -7,6 +7,7 @@ export class RepositoryPromptVersionCriteriaMapper {
   static toFindManyOptions(criteria: PromptVersionsCriteriaFindMany): FindManyOptions<PromptVersionEntity> {
     const where: FindOptionsWhere<PromptVersionEntity> = {};
     const order: FindOptionsOrder<PromptVersionEntity> = {};
+    const withDeleted = criteria.withDeleted ?? false;
 
     if (criteria.name !== undefined) {
       where.name = ILike(`%${criteria.name}%`);
@@ -31,12 +32,6 @@ export class RepositoryPromptVersionCriteriaMapper {
       order.id = criteria.orderBy.id;
     }
 
-    if (criteria.includeDeletedRelations !== undefined && criteria.includeDeletedRelations == true) {
-    } else {
-      where.counselorScopedPrompts = { deletedAt: IsNull() };
-      where.toneScopedPrompts = { deletedAt: IsNull() };
-    }
-
-    return { where, order };
+    return { where, order, withDeleted };
   }
 }

--- a/src/services/counselings/domains/promptVersions/infrastructures/psql-promptVersions.repository.ts
+++ b/src/services/counselings/domains/promptVersions/infrastructures/psql-promptVersions.repository.ts
@@ -6,15 +6,10 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
 import { PromptVersionEntity } from "~common/system/persistences/entities/prompts/PromptVersions.entity";
-import { FindManyOptions, FindOneOptions, FindOptionsRelations, Repository } from "typeorm";
+import { FindManyOptions, FindOneOptions, FindOptionsRelations, Repository, SelectQueryBuilder } from "typeorm";
 
 @Injectable()
 export class PsqlPromptVersionsRepository extends PromptVersionsRepository {
-  private readonly promptVersionsFindOptionsRelation: FindOptionsRelations<PromptVersionEntity> = {
-    counselorScopedPrompts: true,
-    toneScopedPrompts: true,
-  };
-
   constructor(
     @InjectRepository(PromptVersionEntity)
     private readonly promptVersionsRepository: Repository<PromptVersionEntity>,
@@ -22,25 +17,77 @@ export class PsqlPromptVersionsRepository extends PromptVersionsRepository {
     super();
   }
 
+  /**
+   * 항상 Distinct + 부모 Deleted 포함여부 반영
+   */
+  private createBaseQb(withDeleted?: boolean): SelectQueryBuilder<PromptVersionEntity> {
+    const qb = this.promptVersionsRepository.createQueryBuilder().distinct(true);
+    if (withDeleted) {
+      qb.withDeleted();
+    }
+
+    return qb;
+  }
+
+  /**
+   * 삭제되지 않은 자식 관계만 JOIN
+   */
+  private applyLiveRelations(qb: SelectQueryBuilder<PromptVersionEntity>) {
+    const base = qb.alias;
+    const counselScopedPromptAlias = `${base}_csp`;
+    const toneScopedPromptAlias = `${base}_tsp`;
+
+    return qb
+      .leftJoinAndSelect(
+        `${base}.counselorScopedPrompts`,
+        counselScopedPromptAlias,
+        `${counselScopedPromptAlias}.deletedAt IS NULL`,
+      )
+      .leftJoinAndSelect(
+        `${base}.toneScopedPrompts`,
+        toneScopedPromptAlias,
+        `${toneScopedPromptAlias}.deletedAt IS NULL`,
+      );
+  }
+
+  /**
+   * 쿼리 빌더에 검색 옵션 적용
+   * relations 는 무시합니다.( 직접 join 적용 )
+   * withDeleted 는 무시합니다. ( 쿼리빌더 생성 시 적용 )
+   * 현재 자식 객체의 필터링은 지원하지 않습니다.
+   */
+  private applyFindOptions(
+    qb: SelectQueryBuilder<PromptVersionEntity>,
+    options?: FindOneOptions<PromptVersionEntity> | FindManyOptions<PromptVersionEntity>,
+  ) {
+    if (!options) return qb;
+
+    const { relations, withDeleted, ...rest } = options;
+    qb.setFindOptions(rest);
+    return qb;
+  }
+
   override async findByPromptVersionId(
     promptVersionId: UniqueEntityId,
     options?: FindOneOptions<PromptVersionEntity>,
   ): Promise<PromptVersions | null> {
-    const findOneOptions: FindOneOptions<PromptVersionEntity> = options ?? {};
-    findOneOptions.where = {
-      ...findOneOptions.where,
-      id: promptVersionId.getString(),
-    };
-    findOneOptions.withDeleted = true;
-    findOneOptions.relations = { ...findOneOptions.relations, ...this.promptVersionsFindOptionsRelation };
-    const promptVersion = await this.promptVersionsRepository.findOne(findOneOptions);
+    const qb = this.createBaseQb(options?.withDeleted);
+    const base = qb.alias;
+
+    qb.where(`${base}.id = :id`, { id: promptVersionId.getString() });
+    this.applyFindOptions(qb, options);
+    this.applyLiveRelations(qb);
+
+    const promptVersion = await qb.getOne();
     return promptVersion ? PsqlPromptVersionsMapper.toDomain(promptVersion) : null;
   }
 
   override async findMany(options?: FindManyOptions<PromptVersionEntity>): Promise<PromptVersions[]> {
-    const findManyOptions: FindManyOptions<PromptVersionEntity> = options ?? {};
-    findManyOptions.relations = { ...findManyOptions.relations, ...this.promptVersionsFindOptionsRelation };
-    const promptVersions = await this.promptVersionsRepository.find(findManyOptions);
+    const qb = this.createBaseQb(options?.withDeleted);
+    this.applyFindOptions(qb, options);
+    this.applyLiveRelations(qb);
+
+    const promptVersions = await qb.getMany();
     return PsqlPromptVersionsMapper.toDomains(promptVersions);
   }
 

--- a/src/services/counselings/domains/promptVersions/infrastructures/repository-promptVersions.reader.ts
+++ b/src/services/counselings/domains/promptVersions/infrastructures/repository-promptVersions.reader.ts
@@ -13,8 +13,13 @@ export class RepositoryPromptVersionsReader extends PromptVersionsReader {
     super();
   }
 
-  override async findOne(props: { promptVersionId: UniqueEntityId }): Promise<PromptVersions | null> {
-    return this.promptVersionsRepository.findByPromptVersionId(props.promptVersionId);
+  override async findOne(props: {
+    promptVersionId: UniqueEntityId;
+    withDeleted?: boolean;
+  }): Promise<PromptVersions | null> {
+    return this.promptVersionsRepository.findByPromptVersionId(props.promptVersionId, {
+      withDeleted: props.withDeleted,
+    });
   }
 
   override async findMany(props: PromptVersionsCriteriaFindMany): Promise<PromptVersions[]> {

--- a/src/services/counselings/domains/promptVersions/models/promptVersions.ts
+++ b/src/services/counselings/domains/promptVersions/models/promptVersions.ts
@@ -308,6 +308,9 @@ export class PromptVersions extends AggregateRoot<PromptVersionsProps> {
     }
 
     for (const counselorScopedPrompt of promptVersion.counselorScopedPrompts) {
+      if (counselorScopedPrompt.deletedAt !== null) {
+        continue;
+      }
       const clonedCounselorScopedPrompt = CounselorScopedPrompts.createNew({
         promptVersionId: this.id,
         counselorId: counselorScopedPrompt.counselorId,
@@ -320,6 +323,9 @@ export class PromptVersions extends AggregateRoot<PromptVersionsProps> {
     }
 
     for (const toneScopedPrompt of promptVersion.toneScopedPrompts) {
+      if (toneScopedPrompt.deletedAt !== null) {
+        continue;
+      }
       const clonedToneScopedPrompt = ToneScopedPrompts.createNew({
         promptVersionId: this.id,
         toneId: toneScopedPrompt.toneId,

--- a/src/services/counselings/domains/promptVersions/promptVersions.criteria.ts
+++ b/src/services/counselings/domains/promptVersions/promptVersions.criteria.ts
@@ -12,5 +12,5 @@ export type PromptVersionsCriteriaFindMany = {
   orderBy?: {
     id: "ASC" | "DESC";
   };
-  includeDeletedRelations?: boolean;
+  withDeleted?: boolean;
 };

--- a/src/services/counselings/domains/promptVersions/promptVersions.reader.ts
+++ b/src/services/counselings/domains/promptVersions/promptVersions.reader.ts
@@ -6,6 +6,6 @@ import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
 
 @Injectable()
 export abstract class PromptVersionsReader {
-  abstract findOne(props: { promptVersionId: UniqueEntityId }): Promise<PromptVersions | null>;
+  abstract findOne(props: { promptVersionId: UniqueEntityId; withDeleted?: boolean }): Promise<PromptVersions | null>;
   abstract findMany(props: PromptVersionsCriteriaFindMany): Promise<PromptVersions[]>;
 }

--- a/src/services/counselings/domains/promptVersions/promptVersions.service.ts
+++ b/src/services/counselings/domains/promptVersions/promptVersions.service.ts
@@ -17,7 +17,7 @@ export class PromptVersionsService {
     private readonly promptVersionsPersister: PromptVersionsPersister,
   ) {}
 
-  async getOne(props: { promptVersionId: UniqueEntityId }): Promise<PromptVersionInfo> {
+  async getOne(props: { promptVersionId: UniqueEntityId; withDeleted?: boolean }): Promise<PromptVersionInfo> {
     const promptVersion = await this.promptVersionsReader.findOne(props);
     if (!promptVersion) {
       throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "PromptVersion not found");


### PR DESCRIPTION
버전 조회 시 삭제된 자식 객체들이 모두 메모리에 로드되는 문제가 있었습니다.
그로인해 임시버전 조회, 기존 버전 로드 등의 로직에서 의도와 다른 불필요한 객체들이 포함되는 문제가 있었습니다.

삭제된 객체를 포함할 지 여부를 파라미터(withDeleted)로 넘겨받는데 이는 aggregate root 객체의 조회 범위 옵션으로 한정됩니다.
하위 도메인 객체는 항상 삭제되지 않은 객체만 조회되도록 하였습니다. (버전 도메인 객체 특성 및 저희 아키텍쳐 구조 상 이 방식이 괜찮을 거라고 생각했습니다.)

rpc 레벨에서는 findVersionById 메서드에만 withDeleted 옵션을 활성화시켜 기존 상담과의 호환성을 유지하고 그 외 다른 메서드들에서는 해당 옵션을 사용하지 않아 삭제된 객체를 다루지 않도록 하였습니다.

삭제되지 않은 자식 객체조회를 위해서 'deletedAt = null' 조건이 where절보다 leftJoin 의 on 절에 이 포함되어야 될거 같아서 쿼리빌더 사용했습니다.