### PR TITLE
fix: proto enum이 array일때 db io 에서 생기던 에러

### DIFF
--- a/src/common/system/persistences/entities/prompts/counsel-technique-transition-rules.entity.ts
+++ b/src/common/system/persistences/entities/prompts/counsel-technique-transition-rules.entity.ts
@@ -72,20 +72,20 @@ export class CounselTechniqueTransitionRuleEntity extends CoreEntity {
   maxCurrentTechniqueMessageCount: number | null;
 
   // 삶의 영역 및 시간 관련 조건
-  @Column({ type: "simple-array", name: "required_impact_domains", nullable: true, comment: "필수 삶의 영역" })
+  @Column({ type: "int", array: true, name: "required_impact_domains", nullable: true, comment: "필수 삶의 영역" })
   requiredImpactDomains: ImpactDomain[];
 
-  @Column({ type: "simple-array", name: "required_timeframes", nullable: true, comment: "필수 문제 체감 최근성" })
+  @Column({ type: "int", array: true, name: "required_timeframes", nullable: true, comment: "필수 문제 체감 최근성" })
   requiredTimeframes: Timeframe[];
 
   // 감정 관련 조건
-  @Column({ type: "simple-array", name: "required_emotion_primaries", nullable: true, comment: "필수 주요 감정" })
+  @Column({ type: "int", array: true, name: "required_emotion_primaries", nullable: true, comment: "필수 주요 감정" })
   requiredEmotionPrimaries: EmotionPrimary[];
 
-  @Column({ type: "simple-array", name: "required_valences", nullable: true, comment: "필수 정서 쾌·불쾌" })
+  @Column({ type: "int", array: true, name: "required_valences", nullable: true, comment: "필수 정서 쾌·불쾌" })
   requiredValences: Valence[];
 
-  @Column({ type: "simple-array", name: "required_arousal_levels", nullable: true, comment: "필수 각성 수준" })
+  @Column({ type: "int", array: true, name: "required_arousal_levels", nullable: true, comment: "필수 각성 수준" })
   requiredArousalLevels: ArousalLevel[];
 
   @Column({ type: "int", name: "min_emotion_intensity", nullable: true, comment: "최소 감정 강도" })
@@ -95,10 +95,16 @@ export class CounselTechniqueTransitionRuleEntity extends CoreEntity {
   maxEmotionIntensity: number | null;
 
   // 통제감 및 동기 관련 조건
-  @Column({ type: "simple-array", name: "required_perceived_controls", nullable: true, comment: "필수 상황 통제감" })
+  @Column({
+    type: "int",
+    array: true,
+    name: "required_perceived_controls",
+    nullable: true,
+    comment: "필수 상황 통제감",
+  })
   requiredPerceivedControls: PerceivedControl[];
 
-  @Column({ type: "simple-array", name: "required_motivation_stages", nullable: true, comment: "필수 변화 단계" })
+  @Column({ type: "int", array: true, name: "required_motivation_stages", nullable: true, comment: "필수 변화 단계" })
   requiredMotivationStages: MotivationStage[];
 
   @Column({ type: "int", name: "min_self_efficacy", nullable: true, comment: "최소 자기효능감" })
@@ -108,11 +114,17 @@ export class CounselTechniqueTransitionRuleEntity extends CoreEntity {
   maxSelfEfficacy: number | null;
 
   // 사회적 지지 관련 조건
-  @Column({ type: "simple-array", name: "required_social_support_levels", nullable: true, comment: "필수 사회적 지지" })
+  @Column({
+    type: "int",
+    array: true,
+    name: "required_social_support_levels",
+    nullable: true,
+    comment: "필수 사회적 지지",
+  })
   requiredSocialSupportLevels: SocialSupportLevel[];
 
   // 위험 관련 조건
-  @Column({ type: "simple-array", name: "required_risk_kinds", nullable: true, comment: "필수 위험 분류" })
+  @Column({ type: "int", array: true, name: "required_risk_kinds", nullable: true, comment: "필수 위험 분류" })
   requiredRiskKinds: RiskKind[];
 
   @Column({ type: "int", name: "min_risk_severity", nullable: true, comment: "최소 위험 심각도" })
@@ -122,7 +134,7 @@ export class CounselTechniqueTransitionRuleEntity extends CoreEntity {
   maxRiskSeverity: number | null;
 
   // 수면 및 신체 증상 관련 조건
-  @Column({ type: "simple-array", name: "required_sleep_qualities", nullable: true, comment: "필수 수면 질" })
+  @Column({ type: "int", array: true, name: "required_sleep_qualities", nullable: true, comment: "필수 수면 질" })
   requiredSleepQualities: SleepQuality[];
 
   @Column({
@@ -134,11 +146,11 @@ export class CounselTechniqueTransitionRuleEntity extends CoreEntity {
   requiredPhysicalSymptomsPresent: boolean | null;
 
   // 인지 부하 관련 조건
-  @Column({ type: "simple-array", name: "required_cognitive_loads", nullable: true, comment: "필수 인지 부하" })
+  @Column({ type: "int", array: true, name: "required_cognitive_loads", nullable: true, comment: "필수 인지 부하" })
   requiredCognitiveLoads: CognitiveLoad[];
 
   // 동맹 관련 조건
-  @Column({ type: "simple-array", name: "required_alliance_strengths", nullable: true, comment: "필수 라포·동맹" })
+  @Column({ type: "int", array: true, name: "required_alliance_strengths", nullable: true, comment: "필수 라포·동맹" })
   requiredAllianceStrengths: AllianceStrength[];
 
   // 심층 동의 관련 조건

--- a/src/migrations/prompts/1756275896735-proto-enum-list-field.ts
+++ b/src/migrations/prompts/1756275896735-proto-enum-list-field.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ProtoEnumListField1756275896735 implements MigrationInterface {
+  name = "ProtoEnumListField1756275896735";
+
+  // helper 함수를 만들어 반복을 줄입니다.
+  private async changeColumnType(
+    queryRunner: QueryRunner,
+    columnName: string,
+    newType: string,
+    usingClause: string,
+  ): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "counsel_technique_transition_rules" ALTER COLUMN "${columnName}" TYPE ${newType} USING ${usingClause}`,
+    );
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const columns = [
+      "required_impact_domains",
+      "required_timeframes",
+      "required_emotion_primaries",
+      "required_perceived_controls",
+      "required_motivation_stages",
+      "required_social_support_levels",
+      "required_risk_kinds",
+      "required_sleep_qualities",
+      "required_cognitive_loads",
+      "required_alliance_strengths",
+      "required_valences",
+      "required_arousal_levels",
+    ];
+
+    // 각 컬럼에 대해 타입을 integer[]로 변경합니다.
+    for (const column of columns) {
+      // 비어있거나 NULL인 경우를 처리하는 더 안전한 USING 구문
+      const using = `(CASE WHEN "${column}" IS NULL OR "${column}" = '' THEN NULL ELSE string_to_array("${column}", ',')::integer[] END)`;
+      await this.changeColumnType(queryRunner, column, "integer[]", using);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const columns = [
+      "required_impact_domains",
+      "required_timeframes",
+      "required_emotion_primaries",
+      "required_perceived_controls",
+      "required_motivation_stages",
+      "required_social_support_levels",
+      "required_risk_kinds",
+      "required_sleep_qualities",
+      "required_cognitive_loads",
+      "required_alliance_strengths",
+      "required_valences",
+      "required_arousal_levels",
+    ];
+
+    // 각 컬럼에 대해 타입을 다시 text로 되돌립니다.
+    for (const column of columns) {
+      const using = `array_to_string("${column}", ',')`;
+      await this.changeColumnType(queryRunner, column, "text", using);
+    }
+  }
+}

--- a/src/services/counselings/presentations/grpc/counsel-prompts.mapper.ts
+++ b/src/services/counselings/presentations/grpc/counsel-prompts.mapper.ts
@@ -136,6 +136,7 @@ export class SchemaCounselPromptsMapper {
     if (!transitionRule) {
       return null;
     }
+
     return create(CounselTechniqueTransitionRuleSchema, {
       id: transitionRule.id.getString(),
       promptVersionId: transitionRule.promptVersionId.getString(),

--- a/src/services/counselings/presentations/grpc/query/counsel-prompts-query.controller.ts
+++ b/src/services/counselings/presentations/grpc/query/counsel-prompts-query.controller.ts
@@ -240,10 +240,12 @@ export class GrpcCounselPromptQueryController {
       toCounselTechniqueId: toCounselTechniqueId ? new CounselTechniqueId(toCounselTechniqueId) : undefined,
       promptVersionId: promptVersionId ? new PromptVersionId(promptVersionId) : undefined,
     });
-    return create(FindCounselTechniqueTransitionRulesResponseSchema, {
+    const response = create(FindCounselTechniqueTransitionRulesResponseSchema, {
       counselTechniqueTransitionRules: transitionRules.map((rule) =>
         SchemaCounselPromptsMapper.toTransitionRuleProto(rule),
       ),
     });
+
+    return response;
   }
 }


### PR DESCRIPTION
## 발단
Arousal[] 이렇게 proto 직렬화 한 enum을 db에 저장해놓은 엔티티를
다시 proto로 직렬화해서 꺼냈을 때, 만약 단수면 그냥 enum으로 잘 해독되어서 꺼내지는데 복수면 해독이 깨지는 버그가 있었습니다. 원인 찾아서 고쳤습니다.

## 문제 발생의 이유

<img width="723" height="103" alt="image" src="https://github.com/user-attachments/assets/d851139e-b486-4408-b695-c3d134fd59a8" />

원래 psql에 이렇게 저장했는데 이게 orm에서 꺼낼 때
['2', '3'] 이렇게 꺼내집니다.
타입은  requiredEmotionPrimaries: EmotionPrimary[]; 선언은 이렇게 되어있겠지만, 그리고
EmotionPrimary[] 은 number[] 겠지만,,
js 런타임에선 모르죠
저희가 또 조드같은거 쓰는건 아니라 검증도 없구요

근데 여기서
단수조회를 하는 경우엔
['2', '3']  -> [2, 3] -> [AROUSAL_MID, AROUSAL_HIGH] 로
직렬화 및 파싱이 특수하게 되더라고요? 라이브러리에서 해주는 듯
그래서 데이터를 단수로 다루는 api쪽인 단수조회나 생성/수정은 또 됩니다.

근데 복수인 경우
```ts
Rule = {
arousalLevel : ArousalLevel[]
}

data: Rules[]
```
이 케이스에선 ['2', '3'] 라이브러리가 못잡는 지  [AROUSAL_UNSPECIFIED, AROUSAL_UNSPECIFIED] 가 됩니다.

## 해결
<img width="730" height="377" alt="image" src="https://github.com/user-attachments/assets/32713283-13ee-424a-88be-885386d9b252" />

걍 db에서 꺼낼 때 [2,3] 으로 오는 타입으로 db 스키마 변경했습니다
찾느라 죽는줄..
