### PR TITLE
Refactor/context analyze

### DIFF
--- a/src/common/shared-kernel/identifiers/counsel-compress-condition.id.ts
+++ b/src/common/shared-kernel/identifiers/counsel-compress-condition.id.ts
@@ -1,0 +1,9 @@
+import { UniqueEntityId } from "~common/shared-kernel/domains/unique-entity-id";
+
+export class CounselCompressConditionId extends UniqueEntityId {
+  private readonly __brand = "CounselCompressConditionId" as const;
+
+  constructor(id?: string | number) {
+    super(id);
+  }
+}

--- a/src/common/shared/utils/fire-and-forget.ts
+++ b/src/common/shared/utils/fire-and-forget.ts
@@ -1,0 +1,37 @@
+import { Logger } from "@nestjs/common";
+
+/**
+ * Fire-and-forget 실행을 위한 유틸리티 클래스
+ * 동기/비동기 함수를 백그라운드에서 실행하면서 에러를 적절히 처리합니다.
+ */
+export class FireAndForget {
+  private static readonly logger = new Logger(FireAndForget.name);
+
+  /**
+   * 함수를 fire-and-forget 방식으로 실행합니다.
+   * @param fn 실행할 함수
+   * @param context 로깅을 위한 컨텍스트 정보 (optional)
+   * @param onError 에러 발생시 추가 처리 함수 (optional)
+   * @param silent 에러 발생시 로깅을 생략할지 여부 (default: false)
+   */
+  static execute<T>(
+    fn: (() => T) | (() => Promise<T>),
+    options?: {
+      context?: string;
+      onError?: (error: Error) => void;
+      silent?: boolean;
+    },
+  ): void {
+    const { context = "Unknown", onError, silent = false } = options || {};
+
+    Promise.resolve()
+      .then(() => fn())
+      .then(() => {
+        if (!silent) this.logger.debug(`Fire-and-forget succeeded: ${context}`);
+      })
+      .catch((error) => {
+        if (!silent) this.logger.error(`Fire-and-forget failed: ${context}`, error);
+        if (onError) onError(error);
+      });
+  }
+}

--- a/src/common/support/distributed-sync/cache/cache.manager.ts
+++ b/src/common/support/distributed-sync/cache/cache.manager.ts
@@ -1,0 +1,82 @@
+/**
+ * 캐시 매니저 인터페이스
+ * - 기본적인 CRUD 작업과 패턴 기반 삭제 지원
+ * - TTL 기반 만료 처리
+ */
+export abstract class CacheManager {
+  /**
+   * 키-값 저장
+   * @param key 캐시 키
+   * @param value 저장할 값 (JSON 직렬화 가능한 모든 타입)
+   * @param options 캐시 옵션 (TTL, 네임스페이스 등)
+   * @returns 저장 성공 여부
+   */
+  abstract set(key: string, value: any, options?: CacheOptions): Promise<boolean>;
+
+  /**
+   * 값 조회
+   * @param key 캐시 키
+   * @returns 저장된 값 또는 null (만료되었거나 존재하지 않는 경우)
+   */
+  abstract get<T = any>(key: string): Promise<T | null>;
+
+  /**
+   * 키 존재 여부 확인
+   * @param key 캐시 키
+   * @returns 키 존재 여부 (만료된 키는 false)
+   */
+  abstract exists(key: string): Promise<boolean>;
+
+  /**
+   * 키 삭제
+   * @param key 캐시 키
+   * @returns 삭제 성공 여부
+   */
+  abstract delete(key: string): Promise<boolean>;
+
+  /**
+   * 패턴에 매칭되는 모든 키 삭제
+   * @param pattern 삭제할 키 패턴 (예: "user:*", "session:123:*")
+   * @returns 삭제된 키 개수
+   */
+  abstract deletePattern(pattern: string): Promise<number>;
+
+  /**
+   * 키가 존재하지 않을 때만 설정 (원자적 연산)
+   * @param key 캐시 키
+   * @param value 저장할 값
+   * @param options 캐시 옵션 (TTL, 네임스페이스 등)
+   * @returns 설정 성공 여부 (이미 존재하면 false)
+   */
+  abstract setIfNotExists(key: string, value: any, options?: CacheOptions): Promise<boolean>;
+
+  /**
+   * 만료된 키들 정리 (백그라운드 작업)
+   * @returns 정리된 키 개수
+   */
+  abstract cleanup(): Promise<number>;
+
+  /**
+   * 모든 캐시 데이터 삭제
+   * @param pattern 삭제할 패턴 (기본값: "*" - 모든 키)
+   * @returns 삭제된 키 개수
+   */
+  abstract clear(pattern?: string): Promise<number>;
+}
+
+/**
+ * 캐시 설정 옵션
+ */
+export interface CacheOptions {
+  /**
+   * TTL(Time To Live) - 캐시 만료 시간 (밀리초)
+   * @default 60000 (1분)
+   */
+  ttl?: number;
+
+  /**
+   * 네임스페이스 - 키 앞에 자동으로 붙는 접두사
+   * @example "user" -> "user:actual_key"
+   */
+  namespace?: string;
+}

--- a/src/common/support/distributed-sync/cache/infrastructures/in-memory-cache-manager.ts
+++ b/src/common/support/distributed-sync/cache/infrastructures/in-memory-cache-manager.ts
@@ -1,0 +1,223 @@
+import { CacheManager, CacheOptions } from "../cache.manager";
+import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
+
+/**
+ * 인메모리 캐시 매니저 구현체
+ * - Map 기반의 인메모리 저장소 사용
+ * - TTL 기반 만료 처리
+ * - 패턴 매칭을 통한 키 삭제 지원
+ */
+@Injectable()
+export class InMemoryCacheManager extends CacheManager implements OnModuleDestroy {
+  private readonly logger = new Logger(InMemoryCacheManager.name);
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly defaultTtl = 60000; // 1분
+  private cleanupTimer?: NodeJS.Timeout;
+
+  constructor() {
+    super();
+    // 주기적으로 만료된 키들 정리 (30초마다)
+    this.startCleanupTimer();
+  }
+
+  /**
+   * 키-값 저장
+   */
+  async set(key: string, value: any, options?: CacheOptions): Promise<boolean> {
+    try {
+      const fullKey = this.buildKey(key, options?.namespace);
+      const ttl = options?.ttl ?? this.defaultTtl;
+      const expiresAt = Date.now() + ttl;
+
+      const entry: CacheEntry = {
+        value: JSON.stringify(value),
+        expiresAt,
+        createdAt: Date.now(),
+      };
+
+      this.cache.set(fullKey, entry);
+      return true;
+    } catch (error) {
+      this.logger.error(`캐시 저장 실패: ${key}`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 값 조회
+   */
+  async get<T = any>(key: string): Promise<T | null> {
+    try {
+      const fullKey = this.buildKey(key);
+      const entry = this.cache.get(fullKey);
+
+      if (!entry) {
+        return null;
+      }
+
+      // TTL 만료 체크
+      if (Date.now() > entry.expiresAt) {
+        this.cache.delete(fullKey);
+        return null;
+      }
+
+      return JSON.parse(entry.value) as T;
+    } catch (error) {
+      this.logger.error(`캐시 조회 실패: ${key}`, error);
+      return null;
+    }
+  }
+
+  /**
+   * 키 존재 여부 확인
+   */
+  async exists(key: string): Promise<boolean> {
+    const value = await this.get(key);
+    return value !== null;
+  }
+
+  /**
+   * 키 삭제
+   */
+  async delete(key: string): Promise<boolean> {
+    try {
+      const fullKey = this.buildKey(key);
+      return this.cache.delete(fullKey);
+    } catch (error) {
+      this.logger.error(`캐시 삭제 실패: ${key}`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 패턴에 매칭되는 모든 키 삭제
+   */
+  async deletePattern(pattern: string): Promise<number> {
+    try {
+      const regex = this.createPatternRegex(pattern);
+      const keysToDelete: string[] = [];
+
+      for (const key of this.cache.keys()) {
+        if (regex.test(key)) {
+          keysToDelete.push(key);
+        }
+      }
+
+      for (const key of keysToDelete) {
+        this.cache.delete(key);
+      }
+
+      return keysToDelete.length;
+    } catch (error) {
+      this.logger.error(`패턴 삭제 실패: ${pattern}`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * 키가 존재하지 않을 때만 설정 (원자적 연산)
+   */
+  async setIfNotExists(key: string, value: any, options?: CacheOptions): Promise<boolean> {
+    const exists = await this.exists(key);
+    if (exists) {
+      return false;
+    }
+    return this.set(key, value, options);
+  }
+
+  /**
+   * 만료된 키들 정리
+   */
+  async cleanup(): Promise<number> {
+    try {
+      const now = Date.now();
+      const keysToDelete: string[] = [];
+
+      for (const [key, entry] of this.cache.entries()) {
+        if (now > entry.expiresAt) {
+          keysToDelete.push(key);
+        }
+      }
+
+      for (const key of keysToDelete) {
+        this.cache.delete(key);
+      }
+
+      if (keysToDelete.length > 0) {
+        this.logger.debug(`만료된 캐시 ${keysToDelete.length}개 정리 완료`);
+      }
+
+      return keysToDelete.length;
+    } catch (error) {
+      this.logger.error("캐시 정리 실패", error);
+      return 0;
+    }
+  }
+
+  /**
+   * 모든 캐시 데이터 삭제
+   */
+  async clear(pattern = "*"): Promise<number> {
+    try {
+      if (pattern === "*") {
+        const count = this.cache.size;
+        this.cache.clear();
+        return count;
+      }
+
+      return this.deletePattern(pattern);
+    } catch (error) {
+      this.logger.error(`캐시 클리어 실패: ${pattern}`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * 네임스페이스를 포함한 전체 키 생성
+   */
+  private buildKey(key: string, namespace?: string): string {
+    return namespace ? `${namespace}:${key}` : key;
+  }
+
+  /**
+   * 패턴을 정규식으로 변환
+   * @param pattern 패턴 문자열 (예: "user:*", "session:123:*")
+   */
+  private createPatternRegex(pattern: string): RegExp {
+    const escapedPattern = pattern
+      .replace(/[.*+?^${}()|[\]\\]/g, "\\$&") // 특수 문자 이스케이프
+      .replace(/\\\*/g, ".*"); // * -> .*로 변환
+
+    return new RegExp(`^${escapedPattern}$`);
+  }
+
+  /**
+   * 정리 타이머 시작
+   */
+  private startCleanupTimer(): void {
+    this.cleanupTimer = setInterval(async () => {
+      await this.cleanup();
+    }, 30000); // 30초마다 정리
+  }
+
+  /**
+   * 리소스 정리 (애플리케이션 종료 시 호출)
+   */
+  onModuleDestroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
+    this.cache.clear();
+    this.logger.debug("InMemoryCacheManager destroyed");
+  }
+}
+
+/**
+ * 캐시 엔트리 인터페이스
+ */
+interface CacheEntry {
+  value: string; // JSON 직렬화된 값
+  expiresAt: number; // 만료 시간 (타임스탬프)
+  createdAt: number; // 생성 시간 (타임스탬프)
+}

--- a/src/common/support/distributed-sync/distributed-sync.module.ts
+++ b/src/common/support/distributed-sync/distributed-sync.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common";
+import { CacheManager } from "~common/support/distributed-sync/cache/cache.manager";
+import { InMemoryCacheManager } from "~common/support/distributed-sync/cache/infrastructures/in-memory-cache-manager";
+import { CacheBasedLockManager } from "~common/support/distributed-sync/lock/infrastructures/cache-based-lock-manager";
+import { LockManager } from "~common/support/distributed-sync/lock/lock.manager";
+
+@Module({
+  providers: [
+    {
+      provide: CacheManager,
+      useClass: InMemoryCacheManager,
+    },
+    {
+      provide: LockManager,
+      useClass: CacheBasedLockManager,
+    },
+  ],
+  exports: [CacheManager, LockManager],
+})
+export class DistributedSyncModule {}

--- a/src/common/support/distributed-sync/lock/infrastructures/cache-based-lock-manager.ts
+++ b/src/common/support/distributed-sync/lock/infrastructures/cache-based-lock-manager.ts
@@ -1,0 +1,276 @@
+import { CacheManager } from "../../cache/cache.manager";
+import { LockInfo, LockManager, LockOptions, RetryOptions } from "../lock.manager";
+import { Injectable, Logger } from "@nestjs/common";
+
+/**
+ * 캐시 기반 락 매니저 구현체
+ * - CacheManager를 활용한 분산 락 구현
+ * - Redis 등으로 확장 가능한 구조
+ * - 원자적 연산 지원
+ */
+@Injectable()
+export class CacheBasedLockManager extends LockManager {
+  private readonly logger = new Logger(CacheBasedLockManager.name);
+  private readonly defaultTtl = 300000; // 5분
+  private readonly lockPrefix = "lock:";
+
+  constructor(private readonly cacheManager: CacheManager) {
+    super();
+  }
+
+  /**
+   * 락 획득 시도
+   */
+  async acquire(key: string, options?: LockOptions): Promise<boolean> {
+    try {
+      const lockKey = this.buildLockKey(key, options?.namespace);
+      const ttl = options?.ttl ?? this.defaultTtl;
+      const owner = options?.owner ?? this.generateOwner();
+
+      const lockData: CacheLockData = {
+        key,
+        acquiredAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + ttl).toISOString(),
+        ttl,
+        owner,
+      };
+
+      // setIfNotExists를 사용하여 원자적으로 락 획득
+      const acquired = await this.cacheManager.setIfNotExists(lockKey, lockData, { ttl });
+
+      if (acquired) {
+        this.logger.debug(`Lock acquired: ${lockKey}, owner: ${owner}`);
+      } else {
+        this.logger.debug(`Lock acquisition failed: ${lockKey}`);
+      }
+
+      return acquired;
+    } catch (error) {
+      this.logger.error(`Failed to acquire lock: ${key}`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 락 해제
+   */
+  async release(key: string): Promise<boolean> {
+    try {
+      const lockKey = this.buildLockKey(key);
+      const released = await this.cacheManager.delete(lockKey);
+
+      if (released) {
+        this.logger.debug(`Lock released: ${lockKey}`);
+      } else {
+        this.logger.debug(`Lock release failed (not found): ${lockKey}`);
+      }
+
+      return released;
+    } catch (error) {
+      this.logger.error(`Failed to release lock: ${key}`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 락 존재 여부 확인
+   */
+  async isLocked(key: string): Promise<boolean> {
+    try {
+      const lockKey = this.buildLockKey(key);
+      return await this.cacheManager.exists(lockKey);
+    } catch (error) {
+      this.logger.error(`Failed to check lock existence: ${key}`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 락 정보 조회
+   */
+  async getLockInfo(key: string): Promise<LockInfo | null> {
+    try {
+      const lockKey = this.buildLockKey(key);
+      const lockData = await this.cacheManager.get<CacheLockData>(lockKey);
+
+      if (!lockData) {
+        return null;
+      }
+
+      const now = Date.now();
+      const acquiredAt = new Date(lockData.acquiredAt);
+      const expiresAt = new Date(lockData.expiresAt);
+      const isExpired = now >= expiresAt.getTime();
+      const remainingTime = Math.max(0, expiresAt.getTime() - now);
+
+      return {
+        key: lockData.key,
+        acquiredAt,
+        expiresAt,
+        ttl: lockData.ttl,
+        owner: lockData.owner,
+        isExpired,
+        remainingTime,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to get lock info: ${key}`, error);
+      return null;
+    }
+  }
+
+  /**
+   * 락 TTL 연장
+   */
+  async extend(key: string, extendBy: number): Promise<boolean> {
+    try {
+      const lockInfo = await this.getLockInfo(key);
+      if (!lockInfo || lockInfo.isExpired) {
+        return false;
+      }
+
+      const lockKey = this.buildLockKey(key);
+      const newTtl = lockInfo.ttl + extendBy;
+      const newExpiresAt = new Date(Date.now() + newTtl);
+
+      const updatedLockData: CacheLockData = {
+        key: lockInfo.key,
+        acquiredAt: lockInfo.acquiredAt.toISOString(),
+        expiresAt: newExpiresAt.toISOString(),
+        ttl: newTtl,
+        owner: lockInfo.owner,
+      };
+
+      const extended = await this.cacheManager.set(lockKey, updatedLockData, { ttl: newTtl });
+
+      if (extended) {
+        this.logger.debug(`Lock extended: ${lockKey}, new TTL: ${newTtl}ms`);
+      }
+
+      return extended;
+    } catch (error) {
+      this.logger.error(`Failed to extend lock: ${key}`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 패턴에 매칭되는 모든 락 해제
+   */
+  async releasePattern(pattern: string): Promise<number> {
+    try {
+      const lockPattern = this.buildLockKey(pattern);
+      const releasedCount = await this.cacheManager.deletePattern(lockPattern);
+
+      if (releasedCount > 0) {
+        this.logger.debug(`Released ${releasedCount} locks matching pattern: ${pattern}`);
+      }
+
+      return releasedCount;
+    } catch (error) {
+      this.logger.error(`Failed to release locks by pattern: ${pattern}`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * 락 획득 시도 with 재시도
+   */
+  async acquireWithRetry(key: string, options?: LockOptions, retryOptions?: RetryOptions): Promise<boolean> {
+    const maxRetries = retryOptions?.maxRetries ?? 3;
+    const baseDelay = retryOptions?.retryDelay ?? 100;
+    const backoffStrategy = retryOptions?.backoffStrategy ?? "fixed";
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const acquired = await this.acquire(key, options);
+      if (acquired) {
+        if (attempt > 0) {
+          this.logger.debug(`Lock acquired after ${attempt} retries: ${key}`);
+        }
+        return true;
+      }
+
+      // 마지막 시도가 아니면 대기
+      if (attempt < maxRetries) {
+        const delay = this.calculateDelay(baseDelay, attempt, backoffStrategy);
+        await this.sleep(delay);
+      }
+    }
+
+    this.logger.debug(`Failed to acquire lock after ${maxRetries} retries: ${key}`);
+    return false;
+  }
+
+  /**
+   * 만료된 락들 정리
+   */
+  async cleanup(): Promise<number> {
+    try {
+      // 캐시 매니저의 cleanup을 활용
+      return await this.cacheManager.cleanup();
+    } catch (error) {
+      this.logger.error("Failed to cleanup expired locks", error);
+      return 0;
+    }
+  }
+
+  /**
+   * 모든 락 해제
+   */
+  async clear(pattern = "*"): Promise<number> {
+    try {
+      const lockPattern = this.buildLockKey(pattern);
+      return await this.cacheManager.clear(lockPattern);
+    } catch (error) {
+      this.logger.error(`Failed to clear locks: ${pattern}`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * 락 키 생성 (네임스페이스 포함)
+   */
+  private buildLockKey(key: string, namespace?: string): string {
+    const baseKey = namespace ? `${namespace}:${key}` : key;
+    return `${this.lockPrefix}${baseKey}`;
+  }
+
+  /**
+   * 소유자 ID 생성
+   */
+  private generateOwner(): string {
+    return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  }
+
+  /**
+   * 재시도 지연 시간 계산
+   */
+  private calculateDelay(baseDelay: number, attempt: number, strategy: string): number {
+    switch (strategy) {
+      case "exponential":
+        return baseDelay * Math.pow(2, attempt);
+      case "linear":
+        return baseDelay * (attempt + 1);
+      case "fixed":
+      default:
+        return baseDelay;
+    }
+  }
+
+  /**
+   * 지연 함수
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+/**
+ * 캐시에 저장되는 락 데이터 구조
+ */
+interface CacheLockData {
+  key: string;
+  acquiredAt: string; // ISO string
+  expiresAt: string; // ISO string
+  ttl: number;
+  owner?: string;
+}

--- a/src/common/support/distributed-sync/lock/lock.manager.ts
+++ b/src/common/support/distributed-sync/lock/lock.manager.ts
@@ -1,0 +1,159 @@
+/**
+ * 락 매니저 인터페이스
+ * - 분산 환경에서의 동시성 제어
+ * - TTL 기반 자동 만료 처리
+ * - 패턴 기반 락 관리
+ */
+export abstract class LockManager {
+  /**
+   * 락 획득 시도
+   * @param key 락 키
+   * @param options 락 옵션 (TTL, 네임스페이스 등)
+   * @returns 락 획득 성공 여부
+   */
+  abstract acquire(key: string, options?: LockOptions): Promise<boolean>;
+
+  /**
+   * 락 해제
+   * @param key 락 키
+   * @returns 해제 성공 여부 (락이 존재하지 않으면 false)
+   */
+  abstract release(key: string): Promise<boolean>;
+
+  /**
+   * 락 존재 여부 확인 (만료되지 않은 락만)
+   * @param key 락 키
+   * @returns 활성 락 존재 여부
+   */
+  abstract isLocked(key: string): Promise<boolean>;
+
+  /**
+   * 락 정보 조회
+   * @param key 락 키
+   * @returns 락 정보 또는 null (존재하지 않거나 만료된 경우)
+   */
+  abstract getLockInfo(key: string): Promise<LockInfo | null>;
+
+  /**
+   * 락 TTL 연장
+   * @param key 락 키
+   * @param extendBy 연장할 시간 (밀리초)
+   * @returns 연장 성공 여부
+   */
+  abstract extend(key: string, extendBy: number): Promise<boolean>;
+
+  /**
+   * 패턴에 매칭되는 모든 락 해제
+   * @param pattern 해제할 락 패턴 (예: "user:*", "session:123:*")
+   * @returns 해제된 락 개수
+   */
+  abstract releasePattern(pattern: string): Promise<number>;
+
+  /**
+   * 락 획득 시도 with 재시도
+   * @param key 락 키
+   * @param options 락 옵션
+   * @param retryOptions 재시도 옵션
+   * @returns 락 획득 성공 여부
+   */
+  abstract acquireWithRetry(key: string, options?: LockOptions, retryOptions?: RetryOptions): Promise<boolean>;
+
+  /**
+   * 만료된 락들 정리 (백그라운드 작업)
+   * @returns 정리된 락 개수
+   */
+  abstract cleanup(): Promise<number>;
+
+  /**
+   * 모든 락 해제
+   * @param pattern 해제할 패턴 (기본값: "*" - 모든 락)
+   * @returns 해제된 락 개수
+   */
+  abstract clear(pattern?: string): Promise<number>;
+}
+
+/**
+ * 락 설정 옵션
+ */
+export interface LockOptions {
+  /**
+   * TTL(Time To Live) - 락 만료 시간 (밀리초)
+   * @default 300000 (5분)
+   */
+  ttl?: number;
+
+  /**
+   * 네임스페이스 - 키 앞에 자동으로 붙는 접두사
+   * @example "counsel" -> "counsel:actual_key"
+   */
+  namespace?: string;
+
+  /**
+   * 락 소유자 식별자 (선택적)
+   * @description 락을 소유한 프로세스나 스레드 식별용
+   */
+  owner?: string;
+}
+
+/**
+ * 재시도 옵션
+ */
+export interface RetryOptions {
+  /**
+   * 최대 재시도 횟수
+   * @default 3
+   */
+  maxRetries?: number;
+
+  /**
+   * 재시도 간격 (밀리초)
+   * @default 100
+   */
+  retryDelay?: number;
+
+  /**
+   * 백오프 전략
+   * @default "fixed"
+   */
+  backoffStrategy?: "fixed" | "exponential" | "linear";
+}
+
+/**
+ * 락 정보
+ */
+export interface LockInfo {
+  /**
+   * 락 키
+   */
+  key: string;
+
+  /**
+   * 락 획득 시간
+   */
+  acquiredAt: Date;
+
+  /**
+   * 락 만료 시간
+   */
+  expiresAt: Date;
+
+  /**
+   * TTL (밀리초)
+   */
+  ttl: number;
+
+  /**
+   * 락 소유자 (있는 경우)
+   */
+  owner?: string;
+
+  /**
+   * 만료 여부
+   */
+  isExpired: boolean;
+
+  /**
+   * 남은 시간 (밀리초)
+   */
+  remainingTime: number;
+}

--- a/src/common/system/persistences/entities/counsels/counsel-compress-conditions.entity.ts
+++ b/src/common/system/persistences/entities/counsels/counsel-compress-conditions.entity.ts
@@ -1,0 +1,31 @@
+import { CoreEntity } from "~common/system/persistences/entities/core.entity";
+import { CounselsEntity } from "~common/system/persistences/entities/counsels/counsel.entity";
+import { Column, Entity, JoinColumn, OneToOne, RelationId } from "typeorm";
+
+@Entity({ name: "counsel_compress_conditions", comment: "상담 압축 조건" })
+export class CounselCompressConditionsEntity extends CoreEntity {
+  @Column({
+    type: "int",
+    name: "message_count_at_last_compression",
+    default: 0,
+    comment: "마지막 압축 시점의 메시지 수",
+  })
+  messageCountAtLastCompression: number;
+
+  @Column({
+    type: "timestamp",
+    name: "last_message_compressed_at",
+    nullable: true,
+    comment: "마지막 메시지 압축일시",
+  })
+  lastMessageCompressedAt: string | null;
+
+  // 관계 (counsel_id)
+  @OneToOne(() => CounselsEntity, (counsel) => counsel.compressCondition, { onUpdate: "CASCADE", onDelete: "CASCADE" })
+  @JoinColumn({ name: "counsel_id" })
+  counsel!: CounselsEntity;
+
+  @RelationId((entity: CounselCompressConditionsEntity) => entity.counsel)
+  @Column({ type: "bigint", name: "counsel_id", comment: "상담 ID" })
+  counselId!: string;
+}

--- a/src/common/system/persistences/entities/counsels/counsel-contexts.entity.ts
+++ b/src/common/system/persistences/entities/counsels/counsel-contexts.entity.ts
@@ -15,33 +15,21 @@ import {
 
 import { CoreEntity } from "~common/system/persistences/entities/core.entity";
 import { CounselsEntity } from "~common/system/persistences/entities/counsels/counsel.entity";
-import { Column, Entity, JoinColumn, OneToOne, RelationId } from "typeorm";
+import { CounselTechniquesEntity } from "~common/system/persistences/entities/prompts/counsel-techniques.entity";
+import { Column, Entity, JoinColumn, ManyToOne, OneToOne, RelationId } from "typeorm";
 
 @Entity({ name: "counsel_contexts", comment: "상담 컨텍스트" })
 export class CounselContextsEntity extends CoreEntity {
   @Column({
     type: "int",
-    name: "not_compressed_message_count",
+    name: "message_count_at_last_transition",
     default: 0,
-    comment: "압축되지 않은 메시지 수",
+    comment: "마지막 기법 전이 시점의 메시지 수",
   })
-  notCompressedMessageCount: number;
+  messageCountAtLastTransition: number;
 
-  @Column({
-    type: "timestamp",
-    name: "last_message_compressed_at",
-    nullable: true,
-    comment: "마지막 메시지 압축일시",
-  })
-  lastMessageCompressedAt: string | null;
-
-  @Column({
-    type: "int",
-    name: "current_technique_message_count",
-    default: 0,
-    comment: "현 기법에서 누적 메시지 수(>=0)",
-  })
-  currentTechniqueMessageCount!: number;
+  @Column({ type: "bigint", name: "counsel_technique_id", comment: "상담 기법 ID" })
+  counselTechniqueId: string;
 
   @Column({ type: "int", name: "impact_domain", nullable: true, comment: "삶의 영역" })
   impactDomain!: ImpactDomain;
@@ -93,6 +81,13 @@ export class CounselContextsEntity extends CoreEntity {
 
   @Column({ type: "boolean", name: "consent_to_depth", nullable: true, comment: "심층 동의" })
   consentToDepth!: boolean | null;
+
+  @ManyToOne(() => CounselTechniquesEntity, (counselTechnique) => counselTechnique.counselContexts, {
+    onDelete: "CASCADE",
+    onUpdate: "CASCADE",
+  })
+  @JoinColumn({ name: "counsel_technique_id" })
+  counselTechnique!: CounselTechniquesEntity;
 
   @OneToOne(() => CounselsEntity, (counsel) => counsel.counselContext, {
     onDelete: "CASCADE",

--- a/src/common/system/persistences/entities/counsels/counsel.entity.ts
+++ b/src/common/system/persistences/entities/counsels/counsel.entity.ts
@@ -1,8 +1,8 @@
 import { CoreEntity } from "~common/system/persistences/entities/core.entity";
 import { CounselorEntity } from "~common/system/persistences/entities/counselors/counselor.entity";
+import { CounselCompressConditionsEntity } from "~common/system/persistences/entities/counsels/counsel-compress-conditions.entity";
 import { CounselContextsEntity } from "~common/system/persistences/entities/counsels/counsel-contexts.entity";
 import { CounselMessagesEntity } from "~common/system/persistences/entities/counsels/counsel-messages.entity";
-import { CounselTechniquesEntity } from "~common/system/persistences/entities/prompts/counsel-techniques.entity";
 import { PromptVersionEntity } from "~common/system/persistences/entities/prompts/prompt-versions.entity";
 import { UsersEntity } from "~common/system/persistences/entities/users/users.entity";
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, RelationId } from "typeorm";
@@ -81,21 +81,6 @@ export class CounselsEntity extends CoreEntity {
   })
   promptVersionId: string;
 
-  @ManyToOne(() => CounselTechniquesEntity, (counselTechnique) => counselTechnique.counsels, {
-    onDelete: "CASCADE",
-    onUpdate: "CASCADE",
-  })
-  @JoinColumn({ name: "counsel_technique_id" })
-  counselTechnique: CounselTechniquesEntity;
-
-  @RelationId((counsels: CounselsEntity) => counsels.counselTechnique)
-  @Column({
-    type: "bigint",
-    name: "counsel_technique_id",
-    comment: "상담 기법 ID",
-  })
-  counselTechniqueId: string;
-
   // @ManyToOne(() => CounselorUserRelationshipsEntity, (counselorUserRelationship) => counselorUserRelationship.counsels)
   // @JoinColumn({ name: "counselor_user_relationship_id" })
   // counselorUserRelationship: CounselorUserRelationshipsEntity;
@@ -115,4 +100,10 @@ export class CounselsEntity extends CoreEntity {
     orphanedRowAction: "disable",
   })
   counselContext: CounselContextsEntity;
+
+  @OneToOne(() => CounselCompressConditionsEntity, (compressCondition) => compressCondition.counsel, {
+    cascade: true,
+    orphanedRowAction: "disable",
+  })
+  compressCondition: CounselCompressConditionsEntity;
 }

--- a/src/common/system/persistences/entities/prompts/counsel-techniques.entity.ts
+++ b/src/common/system/persistences/entities/prompts/counsel-techniques.entity.ts
@@ -1,6 +1,7 @@
 import { CoreEntity } from "~common/system/persistences/entities/core.entity";
 import { ToneEntity } from "~common/system/persistences/entities/counselors/tone.entity";
 import { CounselsEntity } from "~common/system/persistences/entities/counsels/counsel.entity";
+import { CounselContextsEntity } from "~common/system/persistences/entities/counsels/counsel-contexts.entity";
 import { CounselTechniqueTransitionRuleEntity } from "~common/system/persistences/entities/prompts/counsel-technique-transition-rules.entity";
 import { PromptVersionEntity } from "~common/system/persistences/entities/prompts/prompt-versions.entity";
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, RelationId } from "typeorm";
@@ -66,10 +67,10 @@ export class CounselTechniquesEntity extends CoreEntity {
   @Column({ type: "bigint", name: "prompt_version_id" })
   promptVersionId: string;
 
-  @OneToMany(() => CounselsEntity, (counsel) => counsel.counselTechnique, {
+  @OneToMany(() => CounselContextsEntity, (counselContext) => counselContext.counselTechnique, {
     cascade: true,
   })
-  counsels: CounselsEntity[];
+  counselContexts: CounselContextsEntity[];
 
   @OneToMany(() => CounselTechniqueTransitionRuleEntity, (rule) => rule.fromCounselTechnique, {
     cascade: true,

--- a/src/migrations/counsels/1757897569891-domain-seperation.ts
+++ b/src/migrations/counsels/1757897569891-domain-seperation.ts
@@ -1,0 +1,106 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DomainSeperation1757897569891 implements MigrationInterface {
+    name = 'DomainSeperation1757897569891'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // 1. 새로운 counsel_compress_conditions 테이블 생성
+        await queryRunner.query(`CREATE TABLE "counsel_compress_conditions" ("id" bigint NOT NULL, "created_at" TIMESTAMP NOT NULL, "updated_at" TIMESTAMP NOT NULL, "deleted_at" TIMESTAMP, "message_count_at_last_compression" integer NOT NULL DEFAULT '0', "last_message_compressed_at" TIMESTAMP, "counsel_id" bigint NOT NULL, CONSTRAINT "REL_d4f1447fd87b2315949fc308db" UNIQUE ("counsel_id"), CONSTRAINT "PK_21d3c336c057af4b6ed4ea6adcc" PRIMARY KEY ("id")); COMMENT ON COLUMN "counsel_compress_conditions"."id" IS 'ID'; COMMENT ON COLUMN "counsel_compress_conditions"."created_at" IS '생성일시 (한국시간)'; COMMENT ON COLUMN "counsel_compress_conditions"."updated_at" IS '마지막 수정일시 (한국시간)'; COMMENT ON COLUMN "counsel_compress_conditions"."deleted_at" IS '삭제일시 (한국시간)'; COMMENT ON COLUMN "counsel_compress_conditions"."message_count_at_last_compression" IS '마지막 압축 시점의 메시지 수'; COMMENT ON COLUMN "counsel_compress_conditions"."last_message_compressed_at" IS '마지막 메시지 압축일시'; COMMENT ON COLUMN "counsel_compress_conditions"."counsel_id" IS '상담 ID'`);
+        await queryRunner.query(`COMMENT ON TABLE "counsel_compress_conditions" IS '상담 압축 조건'`);
+
+        // 2. counsel_contexts 테이블에 새 컬럼 추가 (NULL 허용으로 임시 생성)
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" ADD "message_count_at_last_transition" integer NOT NULL DEFAULT '0'`);
+        await queryRunner.query(`COMMENT ON COLUMN "counsel_contexts"."message_count_at_last_transition" IS '마지막 기법 전이 시점의 메시지 수'`);
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" ADD "counsel_technique_id" bigint`);
+        await queryRunner.query(`COMMENT ON COLUMN "counsel_contexts"."counsel_technique_id" IS '상담 기법 ID'`);
+
+        // 3. 기존 데이터 마이그레이션
+        // 3-1. counsel_contexts에 counsel_technique_id 값 설정 (counsels 테이블에서 복사)
+        await queryRunner.query(`
+            UPDATE "counsel_contexts" 
+            SET "counsel_technique_id" = "counsels"."counsel_technique_id"
+            FROM "counsels" 
+            WHERE "counsel_contexts"."counsel_id" = "counsels"."id"
+        `);
+        
+        // 3-2. counsel_compress_conditions 테이블에 기존 데이터 이전
+        await queryRunner.query(`
+            INSERT INTO "counsel_compress_conditions" (
+                "id", 
+                "created_at", 
+                "updated_at", 
+                "deleted_at",
+                "message_count_at_last_compression",
+                "last_message_compressed_at",
+                "counsel_id"
+            )
+            SELECT 
+                "counsel_contexts"."id" + 1000000000 as "id", -- ID 충돌 방지를 위한 오프셋
+                "counsel_contexts"."created_at",
+                "counsel_contexts"."updated_at",
+                "counsel_contexts"."deleted_at",
+                COALESCE("counsel_contexts"."not_compressed_message_count", 0),
+                "counsel_contexts"."last_message_compressed_at",
+                "counsel_contexts"."counsel_id"
+            FROM "counsel_contexts"
+            WHERE "counsel_contexts"."counsel_id" IS NOT NULL
+        `);
+
+        // 4. counsel_technique_id를 NOT NULL로 변경
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" ALTER COLUMN "counsel_technique_id" SET NOT NULL`);
+        
+        // 5. 기존 컬럼들 제거
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" DROP COLUMN "not_compressed_message_count"`);
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" DROP COLUMN "last_message_compressed_at"`);
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" DROP COLUMN "current_technique_message_count"`);
+        
+        // 6. counsels 테이블에서 counsel_technique_id 컬럼 제거 (도메인 분리로 인해 더 이상 필요하지 않음)
+        await queryRunner.query(`ALTER TABLE "counsels" DROP COLUMN "counsel_technique_id"`);
+
+        // 7. FK 제약조건 추가
+        await queryRunner.query(`ALTER TABLE "counsel_compress_conditions" ADD CONSTRAINT "FK_d4f1447fd87b2315949fc308db4" FOREIGN KEY ("counsel_id") REFERENCES "counsels"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" ADD CONSTRAINT "FK_counsel_contexts_counsel_technique_id" FOREIGN KEY ("counsel_technique_id") REFERENCES "counsel_techniques"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // 1. FK 제약조건 제거
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" DROP CONSTRAINT "FK_counsel_contexts_counsel_technique_id"`);
+        await queryRunner.query(`ALTER TABLE "counsel_compress_conditions" DROP CONSTRAINT "FK_d4f1447fd87b2315949fc308db4"`);
+
+        // 2. counsels 테이블에 counsel_technique_id 컬럼 복원
+        await queryRunner.query(`ALTER TABLE "counsels" ADD "counsel_technique_id" bigint`);
+        await queryRunner.query(`COMMENT ON COLUMN "counsels"."counsel_technique_id" IS '상담 기법 ID'`);
+
+        // 3. counsel_contexts에서 counsels로 counsel_technique_id 데이터 복원
+        await queryRunner.query(`
+            UPDATE "counsels" 
+            SET "counsel_technique_id" = "counsel_contexts"."counsel_technique_id"
+            FROM "counsel_contexts" 
+            WHERE "counsels"."id" = "counsel_contexts"."counsel_id"
+        `);
+
+        // 4. counsel_contexts 테이블에 기존 컬럼들 복원
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" ADD "not_compressed_message_count" integer NOT NULL DEFAULT '0'`);
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" ADD "last_message_compressed_at" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" ADD "current_technique_message_count" integer NOT NULL DEFAULT '0'`);
+
+        // 5. 데이터 복원
+        // 5-1. counsel_compress_conditions에서 counsel_contexts로 데이터 복원
+        await queryRunner.query(`
+            UPDATE "counsel_contexts" 
+            SET 
+                "not_compressed_message_count" = "counsel_compress_conditions"."message_count_at_last_compression",
+                "last_message_compressed_at" = "counsel_compress_conditions"."last_message_compressed_at"
+            FROM "counsel_compress_conditions"
+            WHERE "counsel_contexts"."counsel_id" = "counsel_compress_conditions"."counsel_id"
+        `);
+
+        // 6. 새로 추가된 컬럼들 제거
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" DROP COLUMN "counsel_technique_id"`);
+        await queryRunner.query(`ALTER TABLE "counsel_contexts" DROP COLUMN "message_count_at_last_transition"`);
+
+        // 7. counsel_compress_conditions 테이블 제거
+        await queryRunner.query(`DROP TABLE "counsel_compress_conditions"`);
+    }
+
+}

--- a/src/services/counselings/applications/counsel-managements/counsel-managements.facade.ts
+++ b/src/services/counselings/applications/counsel-managements/counsel-managements.facade.ts
@@ -55,7 +55,7 @@ export class CounselManagementsFacade {
         promptVersionId: promptVersion.id,
       },
     });
-    const createdCounsel = await this.counselService.create({
+    const createdCounsel = await this.counselService.initializeCounsel({
       userId,
       counselorId,
       counselTechniqueId: startTechnique.id,

--- a/src/services/counselings/applications/counsel-managements/counsel-managements.module.ts
+++ b/src/services/counselings/applications/counsel-managements/counsel-managements.module.ts
@@ -15,6 +15,7 @@ import { TonePromptsModule } from "~counselings/domains/tone-prompts/tone-prompt
 
 import { Module } from "@nestjs/common";
 import { AssistantAgentModule } from "~common/support/assistant-agents/assistant-agent.module";
+import { DistributedSyncModule } from "~common/support/distributed-sync/distributed-sync.module";
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { AssistantAgentModule } from "~common/support/assistant-agents/assistant
     PersonaPromptsModule,
     TonePromptsModule,
     AssistantAgentModule,
+    DistributedSyncModule,
   ],
   providers: [
     // Facade

--- a/src/services/counselings/applications/counsel-managements/counsel-managements.module.ts
+++ b/src/services/counselings/applications/counsel-managements/counsel-managements.module.ts
@@ -2,6 +2,7 @@ import { CounselManagementsFacade } from "~counselings/applications/counsel-mana
 import { CounselingOrchestrator } from "~counselings/applications/counsel-managements/counseling.orchestrator";
 import { AIResponseGenerator } from "~counselings/applications/counsel-managements/support/ai-response.generator";
 import { ContextManager } from "~counselings/applications/counsel-managements/support/context.manager";
+import { CounselLockManager } from "~counselings/applications/counsel-managements/support/counsel-lock.manager";
 import { CounselTechniquesTransitionExecutor } from "~counselings/applications/counsel-managements/support/counsel-techniques-trainsition.executor";
 import { SystemPromptBuilder } from "~counselings/applications/counsel-managements/support/system-prompt.builder";
 import { TechniqueEvaluationParser } from "~counselings/applications/counsel-managements/support/technique-evaluation.parser";
@@ -35,6 +36,7 @@ import { AssistantAgentModule } from "~common/support/assistant-agents/assistant
     TechniqueEvaluationParser,
     ContextManager,
     CounselTechniquesTransitionExecutor,
+    CounselLockManager,
 
     // Main Orchestrator
     CounselingOrchestrator,

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -1,15 +1,19 @@
 import { AIResponseGenerator } from "~counselings/applications/counsel-managements/support/ai-response.generator";
 import { ContextManager } from "~counselings/applications/counsel-managements/support/context.manager";
-import { CounselLockManager } from "~counselings/applications/counsel-managements/support/counsel-lock.manager";
+import {
+  CounselLockManager,
+  LockType,
+} from "~counselings/applications/counsel-managements/support/counsel-lock.manager";
 import { CounselTechniquesTransitionExecutor } from "~counselings/applications/counsel-managements/support/counsel-techniques-trainsition.executor";
 import { SystemPromptBuilder } from "~counselings/applications/counsel-managements/support/system-prompt.builder";
 import { CounselsService } from "~counselings/domains/counsels/counsels.service";
 import { CounselMessagesInfo } from "~counselings/domains/counsels/models/counsel-message.info";
 import { CounselsInfo } from "~counselings/domains/counsels/models/counsels.info";
 
-import { Injectable, Logger } from "@nestjs/common";
+import { HttpStatus, Injectable, Logger } from "@nestjs/common";
 import { FireAndForget } from "~common/shared/utils/fire-and-forget";
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { HttpStatusBasedRpcException } from "~common/system/filters/exceptions";
 import { Transactional } from "typeorm-transactional";
 
 /**
@@ -42,95 +46,128 @@ export class CounselingOrchestrator {
   }> {
     const { counselId, userMessage } = request;
 
-    // 1. 유저 메시지 생성 및 저장
-    const createdUserMessage = await this.counselService.saveMessage({
-      counselId,
-      message: userMessage,
-      isUserMessage: true,
-    });
+    // 메인 플로우 동시성 제어 - 락 획득
+    if (!this.counselLockManager.tryAcquire(counselId.getString(), LockType.MAIN_FLOW)) {
+      throw new HttpStatusBasedRpcException(
+        HttpStatus.TOO_MANY_REQUESTS,
+        `상담 진행이 이미 처리 중입니다: ${counselId.getString()}`,
+      );
+    }
 
-    // 2. 세션 컨텍스트 구성
-    let session = await this.contextManager.buildCounselSession(counselId);
+    try {
+      // 1. 유저 메시지 생성 및 저장
+      const createdUserMessage = await this.counselService.saveMessage({
+        counselId,
+        message: userMessage,
+        isUserMessage: true,
+      });
 
-    // 3. 프롬프트 구성
-    const systemPrompt = await this.promptBuilder.buildSystemPrompt(session);
-    const conversationHistory = this.counselService.buildHistory({
-      counselId: session.counselId,
-      messages: session.messages,
-      compressedMessages: session.compressedMessages,
-    });
+      // 2. 세션 컨텍스트 구성
+      const session = await this.contextManager.buildCounselSession(counselId);
 
-    // 4. AI 응답 생성
-    const aiResponse = await this.aiGenerator.generateResponse(
-      systemPrompt,
-      conversationHistory,
-      userMessage,
-      session.counselId.getString(),
-      session.promptVersion.aiModel,
-      session.currentTechnique.temperature,
-    );
+      // 3. 프롬프트 구성
+      const systemPrompt = await this.promptBuilder.buildSystemPrompt(session);
+      const conversationHistory = this.counselService.buildHistory({
+        counselId: session.counselId,
+        messages: session.messages,
+        compressedMessages: session.compressedMessages,
+      });
 
-    // 5. 시스템 메시지 생성 및 저장
-    const createdAssistantMessage = await this.counselService.saveMessage({
-      counselId: session.counselId,
-      message: aiResponse,
-      isUserMessage: false,
-    });
-    session = session.withNewMessage(createdAssistantMessage.message);
+      // 4. AI 응답 생성
+      const aiResponse = await this.aiGenerator.generateResponse(
+        systemPrompt,
+        conversationHistory,
+        userMessage,
+        session.counselId.getString(),
+        session.promptVersion.aiModel,
+        session.currentTechnique.temperature,
+      );
 
-    // 6. 백그라운드에서 추가 작업 수행 (상담 맥락을 다루는 별도의 동기적 flow 생성)
+      // 5. 시스템 메시지 생성 및 저장
+      const createdAssistantMessage = await this.counselService.saveMessage({
+        counselId: session.counselId,
+        message: aiResponse,
+        isUserMessage: false,
+      });
+
+      // 메인 플로우 완료 후 백그라운드 작업 시작
+      this.startBackgroundProcessing(counselId);
+
+      return {
+        counsel: session.counsel,
+        createdCounselMessage: createdUserMessage.message,
+        counselorResponseMessage: createdAssistantMessage.message,
+      };
+    } finally {
+      // 메인 플로우 락 해제
+      this.counselLockManager.release(counselId.getString(), LockType.MAIN_FLOW);
+    }
+  }
+
+  /**
+   * 백그라운드 처리 시작 (메인 플로우와 분리)
+   */
+  private startBackgroundProcessing(counselId: CounselId): void {
+    // 1. 메시지 압축로직 실행(백그라운드)
     FireAndForget.execute(
       async () => {
         // counsel별 동시성 제어 - 락 획득 시도
-        if (!this.counselLockManager.tryAcquire(counselId.getString())) {
-          this.logger.debug(`Context processing already in progress: ${counselId.getString()}`);
+        if (!this.counselLockManager.tryAcquire(counselId.getString(), LockType.COMPRESSION)) {
+          this.logger.debug(`Compression processing already in progress: ${counselId.getString()}`);
           return; // 이미 처리 중이면 스킵
         }
 
         try {
-          // 1. 메시지 압축(필요시)
-          if (session.counsel.shouldCompressContext) {
-            try {
-              await this.counselService.compressContext({ counselId: session.counselId });
-            } catch {
-              // 실패해도 무시하고 계속 진행
-            }
-          }
-
-          // 2. 상담 맥락 재구성
           try {
-            await this.counselService.organizeContext({ counselId: counselId });
+            await this.counselService.compressContext({ counselId });
           } catch {
-            // 실패 시 즉시 종료
-            // 맥락분석 실패 -> 기법전환 불필요 -> 종료
-            return;
-          }
-
-          // 3. 세션 최신화
-          const updatedSession = await this.contextManager.buildCounselSession(counselId);
-
-          // 4. 최신화된 세션으로 상담 기법 전환 시도
-          try {
-            await this.counselTechniquesTransitionExecutor.executeTransitionIfPossible(updatedSession);
-          } catch {
-            // 실패 시 무시하고 종료
-            // 기법전환 실패 -> 종료
-            return;
+            // 실패해도 무시
           }
         } finally {
           // 락 해제
-          this.counselLockManager.release(counselId.getString());
+          this.counselLockManager.release(counselId.getString(), LockType.COMPRESSION);
         }
       },
       {
-        context: `Organize context and technique transition: ${counselId.getString()}`,
+        context: `Compress context: ${counselId.getString()}`,
       },
     );
 
-    return {
-      counsel: session.counsel,
-      createdCounselMessage: createdUserMessage.message,
-      counselorResponseMessage: createdAssistantMessage.message,
-    };
+    // 2. 상담 맥락 분석 및 기법 전환 시도(백그라운드) - 동기적 수행
+    FireAndForget.execute(
+      async () => {
+        // counsel별 동시성 제어 - 락 획득 시도
+        if (!this.counselLockManager.tryAcquire(counselId.getString(), LockType.ANALYSIS_TRANSITION)) {
+          this.logger.debug(`Analysis and Transition processing already in progress: ${counselId.getString()}`);
+          return; // 이미 처리 중이면 스킵
+        }
+
+        try {
+          // 1. 상담 맥락 분석
+          try {
+            await this.counselService.organizeContext({ counselId });
+          } catch (error) {
+            // 맥락 분석 실패 시 기법 전이도 수행하지 않음
+            return;
+          }
+
+          // 2. 세션 최신화 (분석 결과 및 현재 상담 메시지 카운트 반영)
+          const updatedSession = await this.contextManager.buildCounselSession(counselId);
+
+          // 3. 상담 기법 전환 시도
+          try {
+            await this.counselTechniquesTransitionExecutor.executeTransitionIfPossible(updatedSession);
+          } catch (error) {
+            // 실패해도 무시
+          }
+        } finally {
+          // 락 해제
+          this.counselLockManager.release(counselId.getString(), LockType.ANALYSIS_TRANSITION);
+        }
+      },
+      {
+        context: `Analyze context and technique transition: ${counselId.getString()}`,
+      },
+    );
   }
 }

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -52,7 +52,7 @@ export class CounselingOrchestrator {
 
     // 3. 프롬프트 구성
     const systemPrompt = await this.promptBuilder.buildSystemPrompt(session);
-    let conversationHistory = this.counselService.buildHistory({
+    const conversationHistory = this.counselService.buildHistory({
       counselId: session.counselId,
       messages: session.messages,
       compressedMessages: session.compressedMessages,
@@ -76,16 +76,19 @@ export class CounselingOrchestrator {
     });
     session = session.withNewMessage(createdAssistantMessage.message);
 
-    conversationHistory = this.counselService.buildHistory({
-      counselId: session.counselId,
-      messages: session.messages,
-      compressedMessages: session.compressedMessages,
-    });
-
-    // 6. 백그라운드에서 맥락 분석 및 기법 전환 수행 (별도의 동기적 flow 생성)
+    // 6. 백그라운드에서 추가 작업 수행 (상담 맥락을 다루는 별도의 동기적 flow 생성)
     FireAndForget.execute(
       async () => {
-        // 상담 맥락 재구성
+        // 1. 메시지 압축(필요시)
+        if (session.counsel.shouldCompressContext) {
+          try {
+            await this.counselService.compressContext({ counselId: session.counselId });
+          } catch {
+            // 실패해도 무시하고 계속 진행
+          }
+        }
+
+        // 2. 상담 맥락 재구성
         try {
           await this.counselService.organizeContext({ counselId: counselId });
         } catch {
@@ -94,14 +97,14 @@ export class CounselingOrchestrator {
           return;
         }
 
-        // 세션 최신화
+        // 3. 세션 최신화
         const updatedSession = await this.contextManager.buildCounselSession(counselId);
 
-        // 최신화된 세션으로 상담 기법 전환 시도
+        // 4. 최신화된 세션으로 상담 기법 전환 시도
         try {
           await this.counselTechniquesTransitionExecutor.executeTransitionIfPossible(updatedSession);
         } catch {
-          // 실패 시 즉시 종료
+          // 실패 시 무시하고 종료
           // 기법전환 실패 -> 종료
           return;
         }

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -47,7 +47,7 @@ export class CounselingOrchestrator {
     const { counselId, userMessage } = request;
 
     // 메인 플로우 동시성 제어 - 락 획득
-    if (!this.counselLockManager.tryAcquire(counselId.getString(), LockType.MAIN_FLOW)) {
+    if (!(await this.counselLockManager.tryAcquire(counselId.getString(), LockType.MAIN_FLOW))) {
       throw new HttpStatusBasedRpcException(
         HttpStatus.TOO_MANY_REQUESTS,
         `상담 진행이 이미 처리 중입니다: ${counselId.getString()}`,
@@ -100,7 +100,7 @@ export class CounselingOrchestrator {
       };
     } finally {
       // 메인 플로우 락 해제
-      this.counselLockManager.release(counselId.getString(), LockType.MAIN_FLOW);
+      await this.counselLockManager.release(counselId.getString(), LockType.MAIN_FLOW);
     }
   }
 
@@ -112,7 +112,7 @@ export class CounselingOrchestrator {
     FireAndForget.execute(
       async () => {
         // counsel별 동시성 제어 - 락 획득 시도
-        if (!this.counselLockManager.tryAcquire(counselId.getString(), LockType.COMPRESSION)) {
+        if (!(await this.counselLockManager.tryAcquire(counselId.getString(), LockType.COMPRESSION))) {
           this.logger.debug(`Compression processing already in progress: ${counselId.getString()}`);
           return; // 이미 처리 중이면 스킵
         }
@@ -125,7 +125,7 @@ export class CounselingOrchestrator {
           }
         } finally {
           // 락 해제
-          this.counselLockManager.release(counselId.getString(), LockType.COMPRESSION);
+          await this.counselLockManager.release(counselId.getString(), LockType.COMPRESSION);
         }
       },
       {
@@ -137,7 +137,7 @@ export class CounselingOrchestrator {
     FireAndForget.execute(
       async () => {
         // counsel별 동시성 제어 - 락 획득 시도
-        if (!this.counselLockManager.tryAcquire(counselId.getString(), LockType.ANALYSIS_TRANSITION)) {
+        if (!(await this.counselLockManager.tryAcquire(counselId.getString(), LockType.ANALYSIS_TRANSITION))) {
           this.logger.debug(`Analysis and Transition processing already in progress: ${counselId.getString()}`);
           return; // 이미 처리 중이면 스킵
         }
@@ -162,7 +162,7 @@ export class CounselingOrchestrator {
           }
         } finally {
           // 락 해제
-          this.counselLockManager.release(counselId.getString(), LockType.ANALYSIS_TRANSITION);
+          await this.counselLockManager.release(counselId.getString(), LockType.ANALYSIS_TRANSITION);
         }
       },
       {

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -7,6 +7,7 @@ import { CounselMessagesInfo } from "~counselings/domains/counsels/models/counse
 import { CounselsInfo } from "~counselings/domains/counsels/models/counsels.info";
 
 import { Injectable, Logger } from "@nestjs/common";
+import { FireAndForget } from "~common/shared/utils/fire-and-forget";
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
 import { Transactional } from "typeorm-transactional";
 
@@ -81,9 +82,34 @@ export class CounselingOrchestrator {
       compressedMessages: session.compressedMessages,
     });
 
-    // 6. 백그라운드에서 기법 전환 평가 수행
-    // this.evaluateTechniqueTransitionInBackground(session);
-    this.counselTechniquesTransitionExecutor.executeTransitionBackgroundIfPossible(session);
+    // 6. 백그라운드에서 맥락 분석 및 기법 전환 수행 (별도의 동기적 flow 생성)
+    FireAndForget.execute(
+      async () => {
+        // 상담 맥락 재구성
+        try {
+          await this.counselService.organizeContext({ counselId: counselId });
+        } catch {
+          // 실패 시 즉시 종료
+          // 맥락분석 실패 -> 기법전환 불필요 -> 종료
+          return;
+        }
+
+        // 세션 최신화
+        const updatedSession = await this.contextManager.buildCounselSession(counselId);
+
+        // 최신화된 세션으로 상담 기법 전환 시도
+        try {
+          await this.counselTechniquesTransitionExecutor.executeTransitionIfPossible(updatedSession);
+        } catch {
+          // 실패 시 즉시 종료
+          // 기법전환 실패 -> 종료
+          return;
+        }
+      },
+      {
+        context: `Organize context and technique transition: ${session.counselId.getString()}`,
+      },
+    );
 
     return {
       counsel: session.counsel,
@@ -91,111 +117,4 @@ export class CounselingOrchestrator {
       counselorResponseMessage: createdAssistantMessage.message,
     };
   }
-
-  /**
-   * 백그라운드에서 기법 전환 평가 및 실행
-   * @param session 상담 세션
-   * @param latestMessage 최신 메시지
-   * @deprecated 기법 전환 평가 기능 비활성화
-   */
-  // @Transactional({ propagation: Propagation.REQUIRES_NEW })
-  // private evaluateTechniqueTransitionInBackground(session: CounselSession): void {
-  //   // 백그라운드 처리를 위해 Promise.resolve()를 사용
-  //   Promise.resolve()
-  //     .then(async () => {
-  //       // 1. 평가 조건 확인
-  //       if (!isDefined(session.currentTechnique.nextTechniqueId)) {
-  //         this.logger.log(`Technique evaluation skipped for counsel ${session.counselId}: No next technique`);
-  //         return;
-  //       }
-  //       if (
-  //         session.messages
-  //           .filter((m) => m.isUserMessage)
-  //           .filter((m) => m.counselTechniqueId.equals(session.currentTechniqueId)).length <
-  //         session.currentTechnique.messageThreshold
-  //       ) {
-  //         this.logger.log(`Technique evaluation skipped for counsel ${session.counselId}: Insufficient messages`);
-  //         return;
-  //       }
-
-  //       // 2. AI 평가 수행
-  //       const decision = await this.performAIEvaluation(session);
-
-  //       // 3. 기법 전환 처리
-  //       if (decision.shouldTransition) {
-  //         await this.counselService.updateCounselTechniqueId({
-  //           counselId: session.counselId,
-  //           counselTechniqueId: session.currentTechnique.nextTechniqueId!,
-  //         });
-  //       }
-
-  //       // 로깅
-  //       if (decision.shouldTransition) {
-  //         this.logger.log(`Technique transition executed for counsel ${session.counselId}`, {
-  //           currentTechniqueId: session.currentTechniqueId,
-  //           scores: decision.scores,
-  //           confidence: decision.confidence,
-  //         });
-  //       } else {
-  //         this.logger.log(`Technique transition not recommended for counsel ${session.counselId}`, {
-  //           currentTechniqueId: session.currentTechniqueId,
-  //           scores: decision.scores,
-  //           confidence: decision.confidence,
-  //         });
-  //       }
-  //     })
-  //     .catch((error) => {
-  //       this.logger.error(`Error in background technique evaluation for counsel ${session.counselId}`, error);
-  //     });
-  // }
-
-  // /**
-  //  * AI 평가 수행 (support 서비스들 활용)
-  //  * @param request 평가 요청
-  //  * @returns 기법 전환 결정
-  //  */
-  // private async performAIEvaluation(session: CounselSession): Promise<TechniqueTransitionDecision> {
-  //   // 현재 기법 메시지들을 대화 히스토리로 구성
-  //   const conversationHistory = this.counselService.buildHistory({
-  //     counselId: session.getCounselId(),
-  //     messages: session.getMessages(),
-  //     compressedMessages: session.getCompressedMessages(),
-  //   });
-  //   const nextTechniqueId = session.getCurrentTechnique().nextTechniqueId;
-
-  //   if (!isDefined(nextTechniqueId)) {
-  //     throw new HttpStatusBasedRpcException(HttpStatus.INTERNAL_SERVER_ERROR, "Next technique not found");
-  //   }
-
-  //   const nextTechnique = await this.counselTechniqueService.getOne({
-  //     counselTechniqueId: nextTechniqueId,
-  //   });
-
-  //   // 기법 평가용 통합 시스템 프롬프트 생성
-  //   const systemPrompt = this.promptBuilder.buildTechniqueEvaluationSystemPrompt({
-  //     currentTechnique: session.getCurrentTechnique(),
-  //     nextTechnique: nextTechnique,
-  //     messageThreshold: session.getCurrentTechnique().messageThreshold,
-  //   });
-
-  //   const evaluationRequest = "please evaluate the technique transition";
-
-  //   // AI 평가 수행
-  //   const aiResponse = await this.aiGenerator.generateResponse(
-  //     systemPrompt,
-  //     conversationHistory,
-  //     evaluationRequest,
-  //     `technique-evaluation-${Date.now()}`,
-  //     AiModel.GPT_4O,
-  //     0,
-  //   );
-
-  //   const userMessageCount = session.getMessages().filter((m) => m.isUserMessage).length;
-
-  //   // 파서를 사용하여 응답 파싱 + 결정 계산
-  //   return this.techniqueEvaluationParser.parseTechniqueEvaluationResponse(aiResponse, {
-  //     messageThreshold: session.getCurrentTechnique().messageThreshold,
-  //     userMessageCount,
-  //   });
-  // }
 }

--- a/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
+++ b/src/services/counselings/applications/counsel-managements/counseling.orchestrator.ts
@@ -1,5 +1,6 @@
 import { AIResponseGenerator } from "~counselings/applications/counsel-managements/support/ai-response.generator";
 import { ContextManager } from "~counselings/applications/counsel-managements/support/context.manager";
+import { CounselLockManager } from "~counselings/applications/counsel-managements/support/counsel-lock.manager";
 import { CounselTechniquesTransitionExecutor } from "~counselings/applications/counsel-managements/support/counsel-techniques-trainsition.executor";
 import { SystemPromptBuilder } from "~counselings/applications/counsel-managements/support/system-prompt.builder";
 import { CounselsService } from "~counselings/domains/counsels/counsels.service";
@@ -25,6 +26,7 @@ export class CounselingOrchestrator {
     private readonly contextManager: ContextManager,
     private readonly counselService: CounselsService,
     private readonly counselTechniquesTransitionExecutor: CounselTechniquesTransitionExecutor,
+    private readonly counselLockManager: CounselLockManager,
   ) {}
 
   /**
@@ -79,38 +81,49 @@ export class CounselingOrchestrator {
     // 6. 백그라운드에서 추가 작업 수행 (상담 맥락을 다루는 별도의 동기적 flow 생성)
     FireAndForget.execute(
       async () => {
-        // 1. 메시지 압축(필요시)
-        if (session.counsel.shouldCompressContext) {
-          try {
-            await this.counselService.compressContext({ counselId: session.counselId });
-          } catch {
-            // 실패해도 무시하고 계속 진행
+        // counsel별 동시성 제어 - 락 획득 시도
+        if (!this.counselLockManager.tryAcquire(counselId.getString())) {
+          this.logger.debug(`Context processing already in progress: ${counselId.getString()}`);
+          return; // 이미 처리 중이면 스킵
+        }
+
+        try {
+          // 1. 메시지 압축(필요시)
+          if (session.counsel.shouldCompressContext) {
+            try {
+              await this.counselService.compressContext({ counselId: session.counselId });
+            } catch {
+              // 실패해도 무시하고 계속 진행
+            }
           }
-        }
 
-        // 2. 상담 맥락 재구성
-        try {
-          await this.counselService.organizeContext({ counselId: counselId });
-        } catch {
-          // 실패 시 즉시 종료
-          // 맥락분석 실패 -> 기법전환 불필요 -> 종료
-          return;
-        }
+          // 2. 상담 맥락 재구성
+          try {
+            await this.counselService.organizeContext({ counselId: counselId });
+          } catch {
+            // 실패 시 즉시 종료
+            // 맥락분석 실패 -> 기법전환 불필요 -> 종료
+            return;
+          }
 
-        // 3. 세션 최신화
-        const updatedSession = await this.contextManager.buildCounselSession(counselId);
+          // 3. 세션 최신화
+          const updatedSession = await this.contextManager.buildCounselSession(counselId);
 
-        // 4. 최신화된 세션으로 상담 기법 전환 시도
-        try {
-          await this.counselTechniquesTransitionExecutor.executeTransitionIfPossible(updatedSession);
-        } catch {
-          // 실패 시 무시하고 종료
-          // 기법전환 실패 -> 종료
-          return;
+          // 4. 최신화된 세션으로 상담 기법 전환 시도
+          try {
+            await this.counselTechniquesTransitionExecutor.executeTransitionIfPossible(updatedSession);
+          } catch {
+            // 실패 시 무시하고 종료
+            // 기법전환 실패 -> 종료
+            return;
+          }
+        } finally {
+          // 락 해제
+          this.counselLockManager.release(counselId.getString());
         }
       },
       {
-        context: `Organize context and technique transition: ${session.counselId.getString()}`,
+        context: `Organize context and technique transition: ${counselId.getString()}`,
       },
     );
 

--- a/src/services/counselings/applications/counsel-managements/models/counsel-session.ts
+++ b/src/services/counselings/applications/counsel-managements/models/counsel-session.ts
@@ -1,6 +1,8 @@
 import { CounselTechniqueInfo } from "~counselings/domains/counsel-techniques/models/counsel-technique.info";
 import { CounselorsInfo } from "~counselings/domains/counselors/models/counselors.info";
 import { CompressedMessagesInfo } from "~counselings/domains/counsels/models/compressed-messages.info";
+import { CounselCompressConditionsInfo } from "~counselings/domains/counsels/models/counsel-compress-conditions.info";
+import { CounselContextsInfo } from "~counselings/domains/counsels/models/counsel-contexts.info";
 import { CounselMessagesInfo } from "~counselings/domains/counsels/models/counsel-message.info";
 import { CounselsInfo } from "~counselings/domains/counsels/models/counsels.info";
 import { PersonaPromptInfo } from "~counselings/domains/persona-prompts/models/persona-prompt.info";
@@ -16,6 +18,8 @@ export type CounselSessionData = {
   counselor: CounselorsInfo;
   messages: CounselMessagesInfo[];
   compressedMessages: CompressedMessagesInfo[];
+  counselContext: CounselContextsInfo;
+  compressCondition: CounselCompressConditionsInfo;
   promptVersion: PromptVersionInfo;
   currentTechnique: CounselTechniqueInfo;
   personaPrompt: PersonaPromptInfo;
@@ -50,6 +54,14 @@ export class CounselSession {
 
   get compressedMessages(): CompressedMessagesInfo[] {
     return this.data.compressedMessages;
+  }
+
+  get counselContext(): CounselContextsInfo {
+    return this.data.counselContext;
+  }
+
+  get compressCondition(): CounselCompressConditionsInfo {
+    return this.data.compressCondition;
   }
 
   get promptVersion(): PromptVersionInfo {
@@ -88,7 +100,7 @@ export class CounselSession {
    * @returns 상담기법 ID
    */
   get currentTechniqueId(): CounselTechniqueId {
-    return this.data.counsel.counselTechniqueId;
+    return this.data.counselContext.counselTechniqueId;
   }
 
   withNewMessage(message: CounselMessagesInfo): CounselSession {
@@ -97,6 +109,8 @@ export class CounselSession {
       counselor: this.data.counselor,
       messages: [...this.data.messages, message],
       compressedMessages: this.data.compressedMessages,
+      counselContext: this.data.counselContext,
+      compressCondition: this.data.compressCondition,
       promptVersion: this.data.promptVersion,
       currentTechnique: this.data.currentTechnique,
       personaPrompt: this.data.personaPrompt,

--- a/src/services/counselings/applications/counsel-managements/support/context.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/context.manager.ts
@@ -22,15 +22,16 @@ export class ContextManager {
 
   async buildCounselSession(counselId: CounselId): Promise<CounselSession> {
     // 병렬로 데이터 수집
-    const { counsel, messages, compressedMessages } = await this.counselService.getSessionInfo({
-      counselId,
-    });
+    const { counsel, messages, compressedMessages, counselContext, compressCondition } =
+      await this.counselService.getSessionInfo({
+        counselId,
+      });
 
     const [counselor, promptVersion, currentTechnique] = await Promise.all([
       this.counselorService.getOne({ counselorId: counsel.counselorId }),
       this.promptVersionsService.getOne({ promptVersionId: counsel.promptVersionId }),
       this.counselTechniqueService.getOne({
-        uniqueCriteria: { type: "counselTechnique", id: counsel.counselTechniqueId },
+        uniqueCriteria: { type: "counselTechnique", id: counselContext.counselTechniqueId },
       }),
     ]);
     const [personaPrompt, tonePrompt] = await Promise.all([
@@ -55,6 +56,8 @@ export class ContextManager {
       counselor,
       messages,
       compressedMessages,
+      counselContext,
+      compressCondition,
       promptVersion,
       currentTechnique,
       personaPrompt,

--- a/src/services/counselings/applications/counsel-managements/support/counsel-lock.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/counsel-lock.manager.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+/**
+ * Counsel별 동시성 제어를 위한 락 매니저
+ * 특정 counsel에 대해 컨텍스트 수정 작업(압축, 분석, 전환)이 동시에 실행되지 않도록 보장
+ */
+@Injectable()
+export class CounselLockManager {
+  private readonly locks = new Map<string, { acquired: Date; ttl: number }>();
+  private readonly logger = new Logger(CounselLockManager.name);
+
+  // 기본 TTL: 60초 (긴 분석 작업도 고려)
+  private static readonly DEFAULT_TTL = 60000;
+
+  /**
+   * 특정 counsel에 대한 락 획득 시도
+   * @param counselId counsel ID (string)
+   * @param ttl 락 유지 시간 (밀리초, 기본값: 60초)
+   * @returns 락 획득 성공 여부
+   */
+  tryAcquire(counselId: string, ttl: number = CounselLockManager.DEFAULT_TTL): boolean {
+    try {
+      const existing = this.locks.get(counselId);
+      const now = Date.now();
+
+      // 기존 락이 있고 아직 유효한 경우
+      if (existing && now - existing.acquired.getTime() < existing.ttl) {
+        this.logger.debug(`Lock already held for counsel: ${counselId}`);
+        return false;
+      }
+
+      // 만료된 락이 있다면 정리
+      if (existing) {
+        this.logger.warn(`Cleaning up expired lock for counsel: ${counselId}`);
+        this.locks.delete(counselId);
+      }
+
+      // 새로운 락 설정
+      this.locks.set(counselId, {
+        acquired: new Date(),
+        ttl,
+      });
+
+      this.logger.debug(`Lock acquired for counsel: ${counselId}, TTL: ${ttl}ms`);
+      return true;
+    } catch (error) {
+      this.logger.error(`Failed to acquire lock for counsel: ${counselId}`, error);
+      return false;
+    }
+  }
+
+  /**
+   * 특정 counsel에 대한 락 해제
+   * @param counselId counsel ID (string)
+   */
+  release(counselId: string): void {
+    try {
+      const removed = this.locks.delete(counselId);
+      if (removed) {
+        this.logger.debug(`Lock released for counsel: ${counselId}`);
+      } else {
+        this.logger.warn(`Attempted to release non-existent lock for counsel: ${counselId}`);
+      }
+    } catch (error) {
+      this.logger.error(`Failed to release lock for counsel: ${counselId}`, error);
+    }
+  }
+
+  /**
+   * 현재 락 상태 조회 (디버깅/모니터링 용도)
+   * @param counselId counsel ID (string)
+   * @returns 락 정보 또는 null
+   */
+  getLockInfo(counselId: string): { acquired: Date; ttl: number; isExpired: boolean } | null {
+    const lockInfo = this.locks.get(counselId);
+    if (!lockInfo) return null;
+
+    const now = Date.now();
+    const isExpired = now - lockInfo.acquired.getTime() >= lockInfo.ttl;
+
+    return {
+      acquired: lockInfo.acquired,
+      ttl: lockInfo.ttl,
+      isExpired,
+    };
+  }
+
+  /**
+   * 모든 만료된 락 정리 (주기적 정리용)
+   * @returns 정리된 락 개수
+   */
+  cleanupExpiredLocks(): number {
+    let cleanedCount = 0;
+    const now = Date.now();
+
+    for (const [counselId, lockInfo] of this.locks.entries()) {
+      if (now - lockInfo.acquired.getTime() >= lockInfo.ttl) {
+        this.locks.delete(counselId);
+        cleanedCount++;
+        this.logger.debug(`Cleaned up expired lock for counsel: ${counselId}`);
+      }
+    }
+
+    if (cleanedCount > 0) {
+      this.logger.log(`Cleaned up ${cleanedCount} expired locks`);
+    }
+
+    return cleanedCount;
+  }
+
+  /**
+   * 현재 활성 락 통계
+   * @returns 락 통계 정보
+   */
+  getStats(): {
+    totalLocks: number;
+    expiredLocks: number;
+    activeLocks: number;
+  } {
+    const now = Date.now();
+    let expiredCount = 0;
+
+    for (const lockInfo of this.locks.values()) {
+      if (now - lockInfo.acquired.getTime() >= lockInfo.ttl) {
+        expiredCount++;
+      }
+    }
+
+    return {
+      totalLocks: this.locks.size,
+      expiredLocks: expiredCount,
+      activeLocks: this.locks.size - expiredCount,
+    };
+  }
+
+  /**
+   * 특정 counsel의 락이 현재 활성 상태인지 확인
+   * @param counselId counsel ID (string)
+   * @returns 활성 락 보유 여부
+   */
+  hasActiveLock(counselId: string): boolean {
+    const lockInfo = this.locks.get(counselId);
+    if (!lockInfo) return false;
+
+    const now = Date.now();
+    return now - lockInfo.acquired.getTime() < lockInfo.ttl;
+  }
+}

--- a/src/services/counselings/applications/counsel-managements/support/counsel-lock.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/counsel-lock.manager.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { LockManager } from "~common/support/distributed-sync/lock/lock.manager";
 
 /**
  * 작업 유형 정의
@@ -13,14 +14,17 @@ export enum LockType {
 /**
  * Counsel별 작업별 동시성 제어를 위한 락 매니저
  * 특정 counsel에 대해 압축, 분석, 전환 작업을 독립적으로 관리
+ * 공용 LockManager를 활용하여 분산 환경 지원
  */
 @Injectable()
 export class CounselLockManager {
-  private readonly locks = new Map<string, { acquired: Date; ttl: number; type: LockType }>();
   private readonly logger = new Logger(CounselLockManager.name);
+  private readonly namespace = "counsel"; // 네임스페이스로 counsel 락 구분
 
   // 기본 TTL: 5분 (긴 분석 작업도 고려)
   private static readonly DEFAULT_TTL = 300000;
+
+  constructor(private readonly lockManager: LockManager) {}
 
   /**
    * 락 키 생성 (counselId + lockType 조합)
@@ -33,40 +37,30 @@ export class CounselLockManager {
    * 특정 counsel에 대한 특정 작업의 락 획득 시도
    * @param counselId counsel ID (string)
    * @param lockType 락 유형 (압축, 분석, 전이 등)
-   * @param ttl 락 유지 시간 (밀리초, 기본값: 60초)
+   * @param ttl 락 유지 시간 (밀리초, 기본값: 5분)
    * @returns 락 획득 성공 여부
    */
-  tryAcquire(
+  async tryAcquire(
     counselId: string,
     lockType: LockType = LockType.GENERAL,
     ttl: number = CounselLockManager.DEFAULT_TTL,
-  ): boolean {
+  ): Promise<boolean> {
     try {
       const lockKey = this.generateLockKey(counselId, lockType);
-      const existing = this.locks.get(lockKey);
-      const now = Date.now();
 
-      // 기존 락이 있고 아직 유효한 경우
-      if (existing && now - existing.acquired.getTime() < existing.ttl) {
-        this.logger.debug(`Lock already held for counsel: ${counselId}, type: ${lockType}`);
-        return false;
-      }
-
-      // 만료된 락이 있다면 정리
-      if (existing) {
-        this.logger.warn(`Cleaning up expired lock for counsel: ${counselId}, type: ${lockType}`);
-        this.locks.delete(lockKey);
-      }
-
-      // 새로운 락 설정
-      this.locks.set(lockKey, {
-        acquired: new Date(),
+      const acquired = await this.lockManager.acquire(lockKey, {
         ttl,
-        type: lockType,
+        namespace: this.namespace,
+        owner: this.generateOwner(),
       });
 
-      this.logger.debug(`Lock acquired for counsel: ${counselId}, type: ${lockType}, TTL: ${ttl}ms`);
-      return true;
+      if (acquired) {
+        this.logger.debug(`Lock acquired for counsel: ${counselId}, type: ${lockType}, TTL: ${ttl}ms`);
+      } else {
+        this.logger.debug(`Lock already held for counsel: ${counselId}, type: ${lockType}`);
+      }
+
+      return acquired;
     } catch (error) {
       this.logger.error(`Failed to acquire lock for counsel: ${counselId}, type: ${lockType}`, error);
       return false;
@@ -78,11 +72,14 @@ export class CounselLockManager {
    * @param counselId counsel ID (string)
    * @param lockType 락 유형 (압축, 분석, 전이 등)
    */
-  release(counselId: string, lockType: LockType = LockType.GENERAL): void {
+  async release(counselId: string, lockType: LockType = LockType.GENERAL): Promise<void> {
     try {
       const lockKey = this.generateLockKey(counselId, lockType);
-      const removed = this.locks.delete(lockKey);
-      if (removed) {
+      const fullKey = `${this.namespace}:${lockKey}`;
+
+      const released = await this.lockManager.release(fullKey);
+
+      if (released) {
         this.logger.debug(`Lock released for counsel: ${counselId}, type: ${lockType}`);
       } else {
         this.logger.warn(`Attempted to release non-existent lock for counsel: ${counselId}, type: ${lockType}`);
@@ -98,46 +95,30 @@ export class CounselLockManager {
    * @param lockType 락 유형 (압축, 분석, 전이 등)
    * @returns 락 정보 또는 null
    */
-  getLockInfo(
+  async getLockInfo(
     counselId: string,
     lockType: LockType = LockType.GENERAL,
-  ): { acquired: Date; ttl: number; type: LockType; isExpired: boolean } | null {
-    const lockKey = this.generateLockKey(counselId, lockType);
-    const lockInfo = this.locks.get(lockKey);
-    if (!lockInfo) return null;
+  ): Promise<{ acquired: Date; ttl: number; type: LockType; isExpired: boolean } | null> {
+    try {
+      const lockKey = this.generateLockKey(counselId, lockType);
+      const fullKey = `${this.namespace}:${lockKey}`;
 
-    const now = Date.now();
-    const isExpired = now - lockInfo.acquired.getTime() >= lockInfo.ttl;
+      const lockInfo = await this.lockManager.getLockInfo(fullKey);
 
-    return {
-      acquired: lockInfo.acquired,
-      ttl: lockInfo.ttl,
-      type: lockInfo.type,
-      isExpired,
-    };
-  }
-
-  /**
-   * 모든 만료된 락 정리 (주기적 정리용)
-   * @returns 정리된 락 개수
-   */
-  cleanupExpiredLocks(): number {
-    let cleanedCount = 0;
-    const now = Date.now();
-
-    for (const [lockKey, lockInfo] of this.locks.entries()) {
-      if (now - lockInfo.acquired.getTime() >= lockInfo.ttl) {
-        this.locks.delete(lockKey);
-        cleanedCount++;
-        this.logger.debug(`Cleaned up expired lock: ${lockKey}`);
+      if (!lockInfo) {
+        return null;
       }
-    }
 
-    if (cleanedCount > 0) {
-      this.logger.log(`Cleaned up ${cleanedCount} expired locks`);
+      return {
+        acquired: lockInfo.acquiredAt,
+        ttl: lockInfo.ttl,
+        type: lockType,
+        isExpired: lockInfo.isExpired,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to get lock info for counsel: ${counselId}, type: ${lockType}`, error);
+      return null;
     }
-
-    return cleanedCount;
   }
 
   /**
@@ -146,13 +127,16 @@ export class CounselLockManager {
    * @param lockType 락 유형 (압축, 분석, 전이 등)
    * @returns 활성 락 보유 여부
    */
-  hasActiveLock(counselId: string, lockType: LockType = LockType.GENERAL): boolean {
-    const lockKey = this.generateLockKey(counselId, lockType);
-    const lockInfo = this.locks.get(lockKey);
-    if (!lockInfo) return false;
+  async hasActiveLock(counselId: string, lockType: LockType = LockType.GENERAL): Promise<boolean> {
+    try {
+      const lockKey = this.generateLockKey(counselId, lockType);
+      const fullKey = `${this.namespace}:${lockKey}`;
 
-    const now = Date.now();
-    return now - lockInfo.acquired.getTime() < lockInfo.ttl;
+      return await this.lockManager.isLocked(fullKey);
+    } catch (error) {
+      this.logger.error(`Failed to check active lock for counsel: ${counselId}, type: ${lockType}`, error);
+      return false;
+    }
   }
 
   /**
@@ -160,33 +144,40 @@ export class CounselLockManager {
    * @param counselId counsel ID (string)
    * @returns 해당 counsel의 모든 락 정보
    */
-  getAllLocksForCounsel(counselId: string): Array<{
-    type: LockType;
-    acquired: Date;
-    ttl: number;
-    isExpired: boolean;
-  }> {
-    const result: Array<{
+  async getAllLocksForCounsel(counselId: string): Promise<
+    Array<{
       type: LockType;
       acquired: Date;
       ttl: number;
       isExpired: boolean;
-    }> = [];
-    const now = Date.now();
+    }>
+  > {
+    try {
+      const result: Array<{
+        type: LockType;
+        acquired: Date;
+        ttl: number;
+        isExpired: boolean;
+      }> = [];
 
-    for (const [lockKey, lockInfo] of this.locks.entries()) {
-      if (lockKey.startsWith(`${counselId}:`)) {
-        const isExpired = now - lockInfo.acquired.getTime() >= lockInfo.ttl;
-        result.push({
-          type: lockInfo.type,
-          acquired: lockInfo.acquired,
-          ttl: lockInfo.ttl,
-          isExpired,
-        });
+      // 모든 락 타입에 대해 개별 조회
+      for (const lockType of Object.values(LockType)) {
+        const lockInfo = await this.getLockInfo(counselId, lockType);
+        if (lockInfo) {
+          result.push({
+            type: lockType,
+            acquired: lockInfo.acquired,
+            ttl: lockInfo.ttl,
+            isExpired: lockInfo.isExpired,
+          });
+        }
       }
-    }
 
-    return result;
+      return result;
+    } catch (error) {
+      this.logger.error(`Failed to get all locks for counsel: ${counselId}`, error);
+      return [];
+    }
   }
 
   /**
@@ -194,21 +185,27 @@ export class CounselLockManager {
    * @param counselId counsel ID (string)
    * @returns 해제된 락 개수
    */
-  releaseAllForCounsel(counselId: string): number {
-    let releasedCount = 0;
+  async releaseAllForCounsel(counselId: string): Promise<number> {
+    try {
+      // counsel의 모든 락 타입에 대해 패턴 매칭으로 해제
+      const pattern = `${this.namespace}:${counselId}:*`;
+      const releasedCount = await this.lockManager.releasePattern(pattern);
 
-    for (const lockKey of this.locks.keys()) {
-      if (lockKey.startsWith(`${counselId}:`)) {
-        this.locks.delete(lockKey);
-        releasedCount++;
-        this.logger.debug(`Released lock: ${lockKey}`);
+      if (releasedCount > 0) {
+        this.logger.log(`Released ${releasedCount} locks for counsel: ${counselId}`);
       }
-    }
 
-    if (releasedCount > 0) {
-      this.logger.log(`Released ${releasedCount} locks for counsel: ${counselId}`);
+      return releasedCount;
+    } catch (error) {
+      this.logger.error(`Failed to release all locks for counsel: ${counselId}`, error);
+      return 0;
     }
+  }
 
-    return releasedCount;
+  /**
+   * 소유자 ID 생성
+   */
+  private generateOwner(): string {
+    return `counsel-lock-${process.pid}-${Date.now()}`;
   }
 }

--- a/src/services/counselings/applications/counsel-managements/support/counsel-lock.manager.ts
+++ b/src/services/counselings/applications/counsel-managements/support/counsel-lock.manager.ts
@@ -1,78 +1,109 @@
 import { Injectable, Logger } from "@nestjs/common";
 
 /**
- * Counsel별 동시성 제어를 위한 락 매니저
- * 특정 counsel에 대해 컨텍스트 수정 작업(압축, 분석, 전환)이 동시에 실행되지 않도록 보장
+ * 작업 유형 정의
+ */
+export enum LockType {
+  COMPRESSION = "compression",
+  ANALYSIS_TRANSITION = "analysis-transition",
+  MAIN_FLOW = "main-flow", // 메인 상담 진행 플로우
+  GENERAL = "general", // 기본 락 타입
+}
+
+/**
+ * Counsel별 작업별 동시성 제어를 위한 락 매니저
+ * 특정 counsel에 대해 압축, 분석, 전환 작업을 독립적으로 관리
  */
 @Injectable()
 export class CounselLockManager {
-  private readonly locks = new Map<string, { acquired: Date; ttl: number }>();
+  private readonly locks = new Map<string, { acquired: Date; ttl: number; type: LockType }>();
   private readonly logger = new Logger(CounselLockManager.name);
 
-  // 기본 TTL: 60초 (긴 분석 작업도 고려)
-  private static readonly DEFAULT_TTL = 60000;
+  // 기본 TTL: 5분 (긴 분석 작업도 고려)
+  private static readonly DEFAULT_TTL = 300000;
 
   /**
-   * 특정 counsel에 대한 락 획득 시도
+   * 락 키 생성 (counselId + lockType 조합)
+   */
+  private generateLockKey(counselId: string, lockType: LockType): string {
+    return `${counselId}:${lockType}`;
+  }
+
+  /**
+   * 특정 counsel에 대한 특정 작업의 락 획득 시도
    * @param counselId counsel ID (string)
+   * @param lockType 락 유형 (압축, 분석, 전이 등)
    * @param ttl 락 유지 시간 (밀리초, 기본값: 60초)
    * @returns 락 획득 성공 여부
    */
-  tryAcquire(counselId: string, ttl: number = CounselLockManager.DEFAULT_TTL): boolean {
+  tryAcquire(
+    counselId: string,
+    lockType: LockType = LockType.GENERAL,
+    ttl: number = CounselLockManager.DEFAULT_TTL,
+  ): boolean {
     try {
-      const existing = this.locks.get(counselId);
+      const lockKey = this.generateLockKey(counselId, lockType);
+      const existing = this.locks.get(lockKey);
       const now = Date.now();
 
       // 기존 락이 있고 아직 유효한 경우
       if (existing && now - existing.acquired.getTime() < existing.ttl) {
-        this.logger.debug(`Lock already held for counsel: ${counselId}`);
+        this.logger.debug(`Lock already held for counsel: ${counselId}, type: ${lockType}`);
         return false;
       }
 
       // 만료된 락이 있다면 정리
       if (existing) {
-        this.logger.warn(`Cleaning up expired lock for counsel: ${counselId}`);
-        this.locks.delete(counselId);
+        this.logger.warn(`Cleaning up expired lock for counsel: ${counselId}, type: ${lockType}`);
+        this.locks.delete(lockKey);
       }
 
       // 새로운 락 설정
-      this.locks.set(counselId, {
+      this.locks.set(lockKey, {
         acquired: new Date(),
         ttl,
+        type: lockType,
       });
 
-      this.logger.debug(`Lock acquired for counsel: ${counselId}, TTL: ${ttl}ms`);
+      this.logger.debug(`Lock acquired for counsel: ${counselId}, type: ${lockType}, TTL: ${ttl}ms`);
       return true;
     } catch (error) {
-      this.logger.error(`Failed to acquire lock for counsel: ${counselId}`, error);
+      this.logger.error(`Failed to acquire lock for counsel: ${counselId}, type: ${lockType}`, error);
       return false;
     }
   }
 
   /**
-   * 특정 counsel에 대한 락 해제
+   * 특정 counsel에 대한 특정 작업의 락 해제
    * @param counselId counsel ID (string)
+   * @param lockType 락 유형 (압축, 분석, 전이 등)
    */
-  release(counselId: string): void {
+  release(counselId: string, lockType: LockType = LockType.GENERAL): void {
     try {
-      const removed = this.locks.delete(counselId);
+      const lockKey = this.generateLockKey(counselId, lockType);
+      const removed = this.locks.delete(lockKey);
       if (removed) {
-        this.logger.debug(`Lock released for counsel: ${counselId}`);
+        this.logger.debug(`Lock released for counsel: ${counselId}, type: ${lockType}`);
       } else {
-        this.logger.warn(`Attempted to release non-existent lock for counsel: ${counselId}`);
+        this.logger.warn(`Attempted to release non-existent lock for counsel: ${counselId}, type: ${lockType}`);
       }
     } catch (error) {
-      this.logger.error(`Failed to release lock for counsel: ${counselId}`, error);
+      this.logger.error(`Failed to release lock for counsel: ${counselId}, type: ${lockType}`, error);
     }
   }
 
   /**
    * 현재 락 상태 조회 (디버깅/모니터링 용도)
    * @param counselId counsel ID (string)
+   * @param lockType 락 유형 (압축, 분석, 전이 등)
    * @returns 락 정보 또는 null
    */
-  getLockInfo(counselId: string): { acquired: Date; ttl: number; isExpired: boolean } | null {
-    const lockInfo = this.locks.get(counselId);
+  getLockInfo(
+    counselId: string,
+    lockType: LockType = LockType.GENERAL,
+  ): { acquired: Date; ttl: number; type: LockType; isExpired: boolean } | null {
+    const lockKey = this.generateLockKey(counselId, lockType);
+    const lockInfo = this.locks.get(lockKey);
     if (!lockInfo) return null;
 
     const now = Date.now();
@@ -81,6 +112,7 @@ export class CounselLockManager {
     return {
       acquired: lockInfo.acquired,
       ttl: lockInfo.ttl,
+      type: lockInfo.type,
       isExpired,
     };
   }
@@ -93,11 +125,11 @@ export class CounselLockManager {
     let cleanedCount = 0;
     const now = Date.now();
 
-    for (const [counselId, lockInfo] of this.locks.entries()) {
+    for (const [lockKey, lockInfo] of this.locks.entries()) {
       if (now - lockInfo.acquired.getTime() >= lockInfo.ttl) {
-        this.locks.delete(counselId);
+        this.locks.delete(lockKey);
         cleanedCount++;
-        this.logger.debug(`Cleaned up expired lock for counsel: ${counselId}`);
+        this.logger.debug(`Cleaned up expired lock: ${lockKey}`);
       }
     }
 
@@ -109,40 +141,74 @@ export class CounselLockManager {
   }
 
   /**
-   * 현재 활성 락 통계
-   * @returns 락 통계 정보
-   */
-  getStats(): {
-    totalLocks: number;
-    expiredLocks: number;
-    activeLocks: number;
-  } {
-    const now = Date.now();
-    let expiredCount = 0;
-
-    for (const lockInfo of this.locks.values()) {
-      if (now - lockInfo.acquired.getTime() >= lockInfo.ttl) {
-        expiredCount++;
-      }
-    }
-
-    return {
-      totalLocks: this.locks.size,
-      expiredLocks: expiredCount,
-      activeLocks: this.locks.size - expiredCount,
-    };
-  }
-
-  /**
-   * 특정 counsel의 락이 현재 활성 상태인지 확인
+   * 특정 counsel의 특정 작업 락이 현재 활성 상태인지 확인
    * @param counselId counsel ID (string)
+   * @param lockType 락 유형 (압축, 분석, 전이 등)
    * @returns 활성 락 보유 여부
    */
-  hasActiveLock(counselId: string): boolean {
-    const lockInfo = this.locks.get(counselId);
+  hasActiveLock(counselId: string, lockType: LockType = LockType.GENERAL): boolean {
+    const lockKey = this.generateLockKey(counselId, lockType);
+    const lockInfo = this.locks.get(lockKey);
     if (!lockInfo) return false;
 
     const now = Date.now();
     return now - lockInfo.acquired.getTime() < lockInfo.ttl;
+  }
+
+  /**
+   * 특정 counsel의 모든 락 정보 조회
+   * @param counselId counsel ID (string)
+   * @returns 해당 counsel의 모든 락 정보
+   */
+  getAllLocksForCounsel(counselId: string): Array<{
+    type: LockType;
+    acquired: Date;
+    ttl: number;
+    isExpired: boolean;
+  }> {
+    const result: Array<{
+      type: LockType;
+      acquired: Date;
+      ttl: number;
+      isExpired: boolean;
+    }> = [];
+    const now = Date.now();
+
+    for (const [lockKey, lockInfo] of this.locks.entries()) {
+      if (lockKey.startsWith(`${counselId}:`)) {
+        const isExpired = now - lockInfo.acquired.getTime() >= lockInfo.ttl;
+        result.push({
+          type: lockInfo.type,
+          acquired: lockInfo.acquired,
+          ttl: lockInfo.ttl,
+          isExpired,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * 특정 counsel의 모든 락 해제
+   * @param counselId counsel ID (string)
+   * @returns 해제된 락 개수
+   */
+  releaseAllForCounsel(counselId: string): number {
+    let releasedCount = 0;
+
+    for (const lockKey of this.locks.keys()) {
+      if (lockKey.startsWith(`${counselId}:`)) {
+        this.locks.delete(lockKey);
+        releasedCount++;
+        this.logger.debug(`Released lock: ${lockKey}`);
+      }
+    }
+
+    if (releasedCount > 0) {
+      this.logger.log(`Released ${releasedCount} locks for counsel: ${counselId}`);
+    }
+
+    return releasedCount;
   }
 }

--- a/src/services/counselings/applications/counsel-managements/support/counsel-techniques-trainsition.executor.ts
+++ b/src/services/counselings/applications/counsel-managements/support/counsel-techniques-trainsition.executor.ts
@@ -25,6 +25,7 @@ export class CounselTechniquesTransitionExecutor {
         await this.counselsService.updateCounselTechniqueId({
           counselId: counselSession.counselId,
           counselTechniqueId: matchingRule.toCounselTechniqueId,
+          currentMessageCount: counselSession.counsel.messageCount,
         });
         this.logger.log(
           `Transitioned counsel ${counselSession.counselId.getString()} to technique ${matchingRule.toCounselTechniqueId.getString()} ` +
@@ -50,8 +51,10 @@ export class CounselTechniquesTransitionExecutor {
       return null;
     }
     // 현재 세션 컨텍스트 정보 추출
-    const currentContext = counselSession.counsel.context;
-    const currentTechniqueMessageCount = currentContext.currentTechniqueMessageCount;
+    const counsel = counselSession.counsel;
+    const currentContext = counselSession.counselContext;
+    const compressCondition = counselSession.compressCondition;
+    const currentTechniqueMessageCount = counsel.messageCount - compressCondition.messageCountAtLastCompression;
 
     // 조건을 만족하는 규칙들을 필터링하고 최고 우선순위 규칙 반환
     const matchingRule = this.findHighestPriorityMatchingRule(

--- a/src/services/counselings/applications/counsel-managements/support/counsel-techniques-trainsition.executor.ts
+++ b/src/services/counselings/applications/counsel-managements/support/counsel-techniques-trainsition.executor.ts
@@ -5,6 +5,7 @@ import { CounselsService } from "~counselings/domains/counsels/counsels.service"
 import { CounselContextsInfo } from "~counselings/domains/counsels/models/counsel-contexts.info";
 
 import { Injectable, Logger } from "@nestjs/common";
+import { Propagation, Transactional } from "typeorm-transactional";
 
 @Injectable()
 export class CounselTechniquesTransitionExecutor {
@@ -15,23 +16,28 @@ export class CounselTechniquesTransitionExecutor {
 
   private readonly logger = new Logger(CounselTechniquesTransitionExecutor.name);
 
-  async executeTransitionBackgroundIfPossible(counselSession: CounselSession): Promise<void> {
-    Promise.resolve()
-      .then(async () => {
-        const matchingRule = await this.evaluateTransition(counselSession);
-        if (matchingRule) {
-          await this.counselsService.updateCounselTechniqueId({
-            counselId: counselSession.counselId,
-            counselTechniqueId: matchingRule.toCounselTechniqueId,
-          });
-        }
-      })
-      .catch((error) => {
-        this.logger.error(
-          `[CounselTechniquesTransitionExecutor] executeTransitionBackgroundIfPossible failed: ${counselSession.counselId}`,
-          error,
+  @Transactional({ propagation: Propagation.REQUIRES_NEW })
+  async executeTransitionIfPossible(counselSession: CounselSession): Promise<void> {
+    try {
+      this.logger.log(`Evaluating technique transition for counsel: ${counselSession.counselId.getString()}`);
+      const matchingRule = await this.evaluateTransition(counselSession);
+      if (matchingRule) {
+        await this.counselsService.updateCounselTechniqueId({
+          counselId: counselSession.counselId,
+          counselTechniqueId: matchingRule.toCounselTechniqueId,
+        });
+        this.logger.log(
+          `Transitioned counsel ${counselSession.counselId.getString()} to technique ${matchingRule.toCounselTechniqueId.getString()} ` +
+            `using rule ${matchingRule.id.getString()}`,
         );
-      });
+      } else {
+        this.logger.log(`No transition rule matched for counsel: ${counselSession.counselId.getString()}`);
+      }
+    } catch (error) {
+      this.logger.error(`executeTransitionIfPossible failed: ${counselSession.counselId.getString()}`, error);
+      // Transaction Rollback
+      throw error;
+    }
   }
 
   private async evaluateTransition(counselSession: CounselSession): Promise<CounselTechniqueTransitionRuleInfo | null> {

--- a/src/services/counselings/domains/counsel-techniques/infrastructures/mappers/typeorm-counsel-techniques.mapper.ts
+++ b/src/services/counselings/domains/counsel-techniques/infrastructures/mappers/typeorm-counsel-techniques.mapper.ts
@@ -51,7 +51,7 @@ export class TypeormCounselTechniquesMapper {
 
     const mappedFields: EntityData<
       CounselTechniquesEntity,
-      "tone" | "promptVersion" | "counsels" | "fromTransitionRules" | "toTransitionRules"
+      "tone" | "promptVersion" | "counselContexts" | "fromTransitionRules" | "toTransitionRules"
     > = {
       id: counselTechniques.id.getString(),
       promptVersionId: counselTechniques.promptVersionId.getString(),

--- a/src/services/counselings/domains/counsels/analyzers/alliance.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/alliance.analyzer.ts
@@ -6,8 +6,7 @@ import {
 } from "~counselings/domains/counsels/analyzers/context-domain.registry";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { AllianceStrength } from "~proto/com/hearlers/v1/model/counsel_pb";
 import { AiModel } from "~proto/com/hearlers/v1/model/counsel_prompt_pb";
 
@@ -27,10 +26,10 @@ export class AllianceAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+  async analyze(counselContext: CounselContexts): Promise<AnalysisResult> {
     const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
-      counselId: counsel.id,
+      counselId: counselContext.counselId,
       limit: 20,
       orderBy: { id: "DESC" },
     });
@@ -42,7 +41,7 @@ export class AllianceAnalyzer extends BaseDomainAnalyzer {
     try {
       const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
       const response = await this.assistantAgent.call({
-        conversationId: counsel.id.toString(),
+        conversationId: counselContext.id.toString(),
         message: this.getUserPrompt(conversationJson),
         systemPrompt: this.getSystemPrompt(),
         aiModel: AiModel.GPT_5,

--- a/src/services/counselings/domains/counsels/analyzers/alliance.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/alliance.analyzer.ts
@@ -1,5 +1,5 @@
 import { AnalyzerValidator } from "~counselings/domains/counsels/analyzers/analyzer.validator";
-import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
+import { AnalysisResult, BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import {
   CONTEXT_DOMAIN_REGISTRY,
   ContextDomain,
@@ -27,26 +27,42 @@ export class AllianceAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>> {
+  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+    const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
       counselId: counsel.id,
       limit: 20,
       orderBy: { id: "DESC" },
     });
-    if (!messages.length) return {};
 
-    const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
-    const response = await this.assistantAgent.call({
-      conversationId: counsel.id.toString(),
-      message: this.getUserPrompt(conversationJson),
-      systemPrompt: this.getSystemPrompt(),
-      aiModel: AiModel.GPT_5,
-      temperature: 0,
-      maxToolCalls: 0,
-      useTools: false,
-    });
+    if (!messages.length) {
+      return this.createFailureResult("No messages found", 0, Date.now() - startTime);
+    }
 
-    return this.pick(response.content);
+    try {
+      const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
+      const response = await this.assistantAgent.call({
+        conversationId: counsel.id.toString(),
+        message: this.getUserPrompt(conversationJson),
+        systemPrompt: this.getSystemPrompt(),
+        aiModel: AiModel.GPT_5,
+        temperature: 0,
+        maxToolCalls: 0,
+        useTools: false,
+      });
+
+      const updates = this.pick(response.content);
+      const processingTime = Date.now() - startTime;
+      const quality = this.assessQuality(updates, response.content);
+
+      return this.createResult(updates, messages.length, processingTime, quality);
+    } catch (error) {
+      return this.createFailureResult(
+        error instanceof Error ? error.message : "Unknown error",
+        messages.length,
+        Date.now() - startTime,
+      );
+    }
   }
 
   private getSystemPrompt(): string {

--- a/src/services/counselings/domains/counsels/analyzers/context-analyzer.interface.ts
+++ b/src/services/counselings/domains/counsels/analyzers/context-analyzer.interface.ts
@@ -4,13 +4,92 @@ import { Counsels } from "~counselings/domains/counsels/models/counsels";
 
 import { Injectable } from "@nestjs/common";
 
+export interface AnalysisMetadata {
+  /** 분석에 사용된 메시지 수 */
+  messageCount: number;
+  /** 분석 소요 시간 (ms) */
+  processingTime: number;
+  /** 분석 실패 이유 (실패 시) */
+  failureReason?: string;
+  /** 간단한 품질 지표 */
+  quality: "GOOD" | "PARTIAL" | "POOR";
+}
+
+export interface AnalysisResult {
+  /** 업데이트할 맥락 정보 */
+  updates: Partial<CounselContextsProps>;
+  /** 분석 메타데이터 */
+  metadata: AnalysisMetadata;
+}
+
 export interface DomainAnalyzer {
   readonly domain: ContextDomain;
-  analyze: (counsel: Counsels) => Promise<Partial<CounselContextsProps>>;
+  analyze: (counsel: Counsels) => Promise<AnalysisResult>;
 }
 
 @Injectable()
 export abstract class BaseDomainAnalyzer implements DomainAnalyzer {
   abstract readonly domain: ContextDomain;
-  abstract analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>>;
+  abstract analyze(counsel: Counsels): Promise<AnalysisResult>;
+
+  /**
+   * 분석 결과를 메타데이터와 함께 생성하는 헬퍼 메서드
+   */
+  protected createResult(
+    updates: Partial<CounselContextsProps>,
+    messageCount: number,
+    processingTime: number,
+    quality: "GOOD" | "PARTIAL" | "POOR" = "GOOD",
+  ): AnalysisResult {
+    return {
+      updates,
+      metadata: {
+        messageCount,
+        processingTime,
+        quality,
+      },
+    };
+  }
+
+  /**
+   * 실패 결과를 생성하는 헬퍼 메서드
+   */
+  protected createFailureResult(failureReason: string, messageCount: number, processingTime: number): AnalysisResult {
+    return {
+      updates: {},
+      metadata: {
+        messageCount,
+        processingTime,
+        failureReason,
+        quality: "POOR",
+      },
+    };
+  }
+
+  /**
+   * 간단한 품질 판단: 추출된 필드 수와 응답 유효성 기반
+   */
+  protected assessQuality(updates: Partial<CounselContextsProps>, rawResponse: string): "GOOD" | "PARTIAL" | "POOR" {
+    const fieldCount = Object.keys(updates).length;
+    const hasValidJson = this.isValidJson(rawResponse);
+
+    if (fieldCount >= 3 && hasValidJson) return "GOOD";
+    if (fieldCount >= 1 && hasValidJson) return "PARTIAL";
+    return "POOR";
+  }
+
+  /**
+   * JSON 유효성 간단 체크
+   */
+  private isValidJson(rawResponse: string): boolean {
+    try {
+      const startIndex = rawResponse.indexOf("{");
+      const endIndex = rawResponse.lastIndexOf("}") + 1;
+      if (startIndex === -1 || endIndex === 0) return false;
+      JSON.parse(rawResponse.slice(startIndex, endIndex));
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/src/services/counselings/domains/counsels/analyzers/context-analyzer.interface.ts
+++ b/src/services/counselings/domains/counsels/analyzers/context-analyzer.interface.ts
@@ -1,6 +1,5 @@
 import { ContextDomain } from "~counselings/domains/counsels/analyzers/context-domain.registry";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 
 import { Injectable } from "@nestjs/common";
 
@@ -24,13 +23,13 @@ export interface AnalysisResult {
 
 export interface DomainAnalyzer {
   readonly domain: ContextDomain;
-  analyze: (counsel: Counsels) => Promise<AnalysisResult>;
+  analyze: (counselContext: CounselContexts) => Promise<AnalysisResult>;
 }
 
 @Injectable()
 export abstract class BaseDomainAnalyzer implements DomainAnalyzer {
   abstract readonly domain: ContextDomain;
-  abstract analyze(counsel: Counsels): Promise<AnalysisResult>;
+  abstract analyze(counselContext: CounselContexts): Promise<AnalysisResult>;
 
   /**
    * 분석 결과를 메타데이터와 함께 생성하는 헬퍼 메서드

--- a/src/services/counselings/domains/counsels/analyzers/context-reviewer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/context-reviewer.ts
@@ -141,8 +141,6 @@ IMPACT & TIMEFRAME:
 - Timeframe: ${FIELD_DESCRIPTIONS.timeframe.values[context.timeframe] || `Unknown (${context.timeframe})`}
 
 ADDITIONAL INFO:
-- Physical Symptoms Present: ${context.physicalSymptomsPresent ?? "Not specified"}
-- Current Technique Message Count: ${context.currentTechniqueMessageCount}
-- Not Compressed Message Count: ${context.notCompressedMessageCount}`;
+- Physical Symptoms Present: ${context.physicalSymptomsPresent ?? "Not specified"}`;
   }
 }

--- a/src/services/counselings/domains/counsels/analyzers/emotion.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/emotion.analyzer.ts
@@ -7,8 +7,7 @@ import {
 } from "~counselings/domains/counsels/analyzers/context-domain.registry";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { ArousalLevel, EmotionPrimary, Valence } from "~proto/com/hearlers/v1/model/counsel_pb";
 import { AiModel } from "~proto/com/hearlers/v1/model/counsel_prompt_pb";
 
@@ -28,10 +27,10 @@ export class EmotionAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+  async analyze(counselContext: CounselContexts): Promise<AnalysisResult> {
     const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
-      counselId: counsel.id,
+      counselId: counselContext.counselId,
       limit: 20,
       orderBy: { id: "DESC" },
     });
@@ -43,7 +42,7 @@ export class EmotionAnalyzer extends BaseDomainAnalyzer {
     try {
       const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
       const response = await this.assistantAgent.call({
-        conversationId: counsel.id.toString(),
+        conversationId: counselContext.counselId.toString(),
         message: this.getUserPrompt(conversationJson),
         systemPrompt: this.getSystemPrompt(),
         aiModel: AiModel.GPT_5,

--- a/src/services/counselings/domains/counsels/analyzers/emotion.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/emotion.analyzer.ts
@@ -1,5 +1,5 @@
 import { AnalyzerValidator } from "~counselings/domains/counsels/analyzers/analyzer.validator";
-import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
+import { AnalysisResult, BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import {
   CONTEXT_DOMAIN_REGISTRY,
   ContextDomain,
@@ -28,26 +28,42 @@ export class EmotionAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>> {
+  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+    const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
       counselId: counsel.id,
       limit: 20,
       orderBy: { id: "DESC" },
     });
-    if (!messages.length) return {};
 
-    const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
-    const response = await this.assistantAgent.call({
-      conversationId: counsel.id.toString(),
-      message: this.getUserPrompt(conversationJson),
-      systemPrompt: this.getSystemPrompt(),
-      aiModel: AiModel.GPT_5,
-      temperature: 0,
-      maxToolCalls: 0,
-      useTools: false,
-    });
+    if (!messages.length) {
+      return this.createFailureResult("No messages found", 0, Date.now() - startTime);
+    }
 
-    return this.pick(response.content);
+    try {
+      const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
+      const response = await this.assistantAgent.call({
+        conversationId: counsel.id.toString(),
+        message: this.getUserPrompt(conversationJson),
+        systemPrompt: this.getSystemPrompt(),
+        aiModel: AiModel.GPT_5,
+        temperature: 0,
+        maxToolCalls: 0,
+        useTools: false,
+      });
+
+      const updates = this.pick(response.content);
+      const processingTime = Date.now() - startTime;
+      const quality = this.assessQuality(updates, response.content);
+
+      return this.createResult(updates, messages.length, processingTime, quality);
+    } catch (error) {
+      return this.createFailureResult(
+        error instanceof Error ? error.message : "Unknown error",
+        messages.length,
+        Date.now() - startTime,
+      );
+    }
   }
 
   private getSystemPrompt(): string {

--- a/src/services/counselings/domains/counsels/analyzers/impact-timeframe.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/impact-timeframe.analyzer.ts
@@ -7,8 +7,7 @@ import {
 } from "~counselings/domains/counsels/analyzers/context-domain.registry";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { ImpactDomain, PerceivedControl, Timeframe } from "~proto/com/hearlers/v1/model/counsel_pb";
 import { AiModel } from "~proto/com/hearlers/v1/model/counsel_prompt_pb";
 
@@ -28,10 +27,10 @@ export class ImpactTimeframeAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+  async analyze(counselContext: CounselContexts): Promise<AnalysisResult> {
     const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
-      counselId: counsel.id,
+      counselId: counselContext.counselId,
       limit: 20,
       orderBy: { id: "DESC" },
     });
@@ -43,7 +42,7 @@ export class ImpactTimeframeAnalyzer extends BaseDomainAnalyzer {
     try {
       const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
       const response = await this.assistantAgent.call({
-        conversationId: counsel.id.toString(),
+        conversationId: counselContext.counselId.toString(),
         message: this.getUserPrompt(conversationJson),
         systemPrompt: this.getSystemPrompt(),
         aiModel: AiModel.GPT_5,

--- a/src/services/counselings/domains/counsels/analyzers/impact-timeframe.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/impact-timeframe.analyzer.ts
@@ -1,5 +1,5 @@
 import { AnalyzerValidator } from "~counselings/domains/counsels/analyzers/analyzer.validator";
-import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
+import { AnalysisResult, BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import {
   CONTEXT_DOMAIN_REGISTRY,
   ContextDomain,
@@ -28,26 +28,42 @@ export class ImpactTimeframeAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>> {
+  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+    const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
       counselId: counsel.id,
       limit: 20,
       orderBy: { id: "DESC" },
     });
-    if (!messages.length) return {};
 
-    const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
-    const response = await this.assistantAgent.call({
-      conversationId: counsel.id.toString(),
-      message: this.getUserPrompt(conversationJson),
-      systemPrompt: this.getSystemPrompt(),
-      aiModel: AiModel.GPT_5,
-      temperature: 0,
-      maxToolCalls: 0,
-      useTools: false,
-    });
+    if (!messages.length) {
+      return this.createFailureResult("No messages found", 0, Date.now() - startTime);
+    }
 
-    return this.pick(response.content);
+    try {
+      const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
+      const response = await this.assistantAgent.call({
+        conversationId: counsel.id.toString(),
+        message: this.getUserPrompt(conversationJson),
+        systemPrompt: this.getSystemPrompt(),
+        aiModel: AiModel.GPT_5,
+        temperature: 0,
+        maxToolCalls: 0,
+        useTools: false,
+      });
+
+      const updates = this.pick(response.content);
+      const processingTime = Date.now() - startTime;
+      const quality = this.assessQuality(updates, response.content);
+
+      return this.createResult(updates, messages.length, processingTime, quality);
+    } catch (error) {
+      return this.createFailureResult(
+        error instanceof Error ? error.message : "Unknown error",
+        messages.length,
+        Date.now() - startTime,
+      );
+    }
   }
 
   private getSystemPrompt(): string {

--- a/src/services/counselings/domains/counsels/analyzers/motivation.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/motivation.analyzer.ts
@@ -1,5 +1,5 @@
 import { AnalyzerValidator } from "~counselings/domains/counsels/analyzers/analyzer.validator";
-import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
+import { AnalysisResult, BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import {
   CONTEXT_DOMAIN_REGISTRY,
   ContextDomain,
@@ -28,26 +28,42 @@ export class MotivationAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>> {
+  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+    const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
       counselId: counsel.id,
       limit: 20,
       orderBy: { id: "DESC" },
     });
-    if (!messages.length) return {};
 
-    const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
-    const response = await this.assistantAgent.call({
-      conversationId: counsel.id.toString(),
-      message: this.getUserPrompt(conversationJson),
-      systemPrompt: this.getSystemPrompt(),
-      aiModel: AiModel.GPT_5,
-      temperature: 0,
-      maxToolCalls: 0,
-      useTools: false,
-    });
+    if (!messages.length) {
+      return this.createFailureResult("No messages found", 0, Date.now() - startTime);
+    }
 
-    return this.pick(response.content);
+    try {
+      const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
+      const response = await this.assistantAgent.call({
+        conversationId: counsel.id.toString(),
+        message: this.getUserPrompt(conversationJson),
+        systemPrompt: this.getSystemPrompt(),
+        aiModel: AiModel.GPT_5,
+        temperature: 0,
+        maxToolCalls: 0,
+        useTools: false,
+      });
+
+      const updates = this.pick(response.content);
+      const processingTime = Date.now() - startTime;
+      const quality = this.assessQuality(updates, response.content);
+
+      return this.createResult(updates, messages.length, processingTime, quality);
+    } catch (error) {
+      return this.createFailureResult(
+        error instanceof Error ? error.message : "Unknown error",
+        messages.length,
+        Date.now() - startTime,
+      );
+    }
   }
 
   private getSystemPrompt(): string {

--- a/src/services/counselings/domains/counsels/analyzers/motivation.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/motivation.analyzer.ts
@@ -7,8 +7,7 @@ import {
 } from "~counselings/domains/counsels/analyzers/context-domain.registry";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { MotivationStage } from "~proto/com/hearlers/v1/model/counsel_pb";
 import { AiModel } from "~proto/com/hearlers/v1/model/counsel_prompt_pb";
 
@@ -28,10 +27,10 @@ export class MotivationAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+  async analyze(counselContext: CounselContexts): Promise<AnalysisResult> {
     const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
-      counselId: counsel.id,
+      counselId: counselContext.counselId,
       limit: 20,
       orderBy: { id: "DESC" },
     });
@@ -43,7 +42,7 @@ export class MotivationAnalyzer extends BaseDomainAnalyzer {
     try {
       const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
       const response = await this.assistantAgent.call({
-        conversationId: counsel.id.toString(),
+        conversationId: counselContext.counselId.toString(),
         message: this.getUserPrompt(conversationJson),
         systemPrompt: this.getSystemPrompt(),
         aiModel: AiModel.GPT_5,

--- a/src/services/counselings/domains/counsels/analyzers/risk.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/risk.analyzer.ts
@@ -7,8 +7,7 @@ import {
 } from "~counselings/domains/counsels/analyzers/context-domain.registry";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { RiskKind } from "~proto/com/hearlers/v1/model/counsel_pb";
 import { AiModel } from "~proto/com/hearlers/v1/model/counsel_prompt_pb";
 
@@ -28,10 +27,10 @@ export class RiskAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+  async analyze(counselContext: CounselContexts): Promise<AnalysisResult> {
     const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
-      counselId: counsel.id,
+      counselId: counselContext.counselId,
       limit: 30,
       orderBy: { id: "DESC" },
     });
@@ -43,7 +42,7 @@ export class RiskAnalyzer extends BaseDomainAnalyzer {
     try {
       const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
       const response = await this.assistantAgent.call({
-        conversationId: counsel.id.toString(),
+        conversationId: counselContext.counselId.toString(),
         message: this.getUserPrompt(conversationJson),
         systemPrompt: this.getSystemPrompt(),
         aiModel: AiModel.GPT_5,

--- a/src/services/counselings/domains/counsels/analyzers/risk.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/risk.analyzer.ts
@@ -1,5 +1,5 @@
 import { AnalyzerValidator } from "~counselings/domains/counsels/analyzers/analyzer.validator";
-import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
+import { AnalysisResult, BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import {
   CONTEXT_DOMAIN_REGISTRY,
   ContextDomain,
@@ -28,26 +28,42 @@ export class RiskAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>> {
+  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+    const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
       counselId: counsel.id,
       limit: 30,
       orderBy: { id: "DESC" },
     });
-    if (!messages.length) return {};
 
-    const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
-    const response = await this.assistantAgent.call({
-      conversationId: counsel.id.toString(),
-      message: this.getUserPrompt(conversationJson),
-      systemPrompt: this.getSystemPrompt(),
-      aiModel: AiModel.GPT_5,
-      temperature: 0,
-      maxToolCalls: 0,
-      useTools: false,
-    });
+    if (!messages.length) {
+      return this.createFailureResult("No messages found", 0, Date.now() - startTime);
+    }
 
-    return this.pick(response.content);
+    try {
+      const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
+      const response = await this.assistantAgent.call({
+        conversationId: counsel.id.toString(),
+        message: this.getUserPrompt(conversationJson),
+        systemPrompt: this.getSystemPrompt(),
+        aiModel: AiModel.GPT_5,
+        temperature: 0,
+        maxToolCalls: 0,
+        useTools: false,
+      });
+
+      const updates = this.pick(response.content);
+      const processingTime = Date.now() - startTime;
+      const quality = this.assessQuality(updates, response.content);
+
+      return this.createResult(updates, messages.length, processingTime, quality);
+    } catch (error) {
+      return this.createFailureResult(
+        error instanceof Error ? error.message : "Unknown error",
+        messages.length,
+        Date.now() - startTime,
+      );
+    }
   }
 
   private getSystemPrompt(): string {

--- a/src/services/counselings/domains/counsels/analyzers/support-sleep-cognitive.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/support-sleep-cognitive.analyzer.ts
@@ -7,8 +7,7 @@ import {
 } from "~counselings/domains/counsels/analyzers/context-domain.registry";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { CognitiveLoad, SleepQuality, SocialSupportLevel } from "~proto/com/hearlers/v1/model/counsel_pb";
 import { AiModel } from "~proto/com/hearlers/v1/model/counsel_prompt_pb";
 
@@ -28,10 +27,10 @@ export class SupportSleepCognitiveAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+  async analyze(counselContext: CounselContexts): Promise<AnalysisResult> {
     const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
-      counselId: counsel.id,
+      counselId: counselContext.counselId,
       limit: 20,
       orderBy: { id: "DESC" },
     });
@@ -43,7 +42,7 @@ export class SupportSleepCognitiveAnalyzer extends BaseDomainAnalyzer {
     try {
       const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
       const response = await this.assistantAgent.call({
-        conversationId: counsel.id.toString(),
+        conversationId: counselContext.counselId.toString(),
         message: this.getUserPrompt(conversationJson),
         systemPrompt: this.getSystemPrompt(),
         aiModel: AiModel.GPT_5,

--- a/src/services/counselings/domains/counsels/analyzers/support-sleep-cognitive.analyzer.ts
+++ b/src/services/counselings/domains/counsels/analyzers/support-sleep-cognitive.analyzer.ts
@@ -1,5 +1,5 @@
 import { AnalyzerValidator } from "~counselings/domains/counsels/analyzers/analyzer.validator";
-import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
+import { AnalysisResult, BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import {
   CONTEXT_DOMAIN_REGISTRY,
   ContextDomain,
@@ -28,26 +28,42 @@ export class SupportSleepCognitiveAnalyzer extends BaseDomainAnalyzer {
     super();
   }
 
-  async analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>> {
+  async analyze(counsel: Counsels): Promise<AnalysisResult> {
+    const startTime = Date.now();
     const messages = await this.counselsReader.findManyMessages({
       counselId: counsel.id,
       limit: 20,
       orderBy: { id: "DESC" },
     });
-    if (!messages.length) return {};
 
-    const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
-    const response = await this.assistantAgent.call({
-      conversationId: counsel.id.toString(),
-      message: this.getUserPrompt(conversationJson),
-      systemPrompt: this.getSystemPrompt(),
-      aiModel: AiModel.GPT_5,
-      temperature: 0,
-      maxToolCalls: 0,
-      useTools: false,
-    });
+    if (!messages.length) {
+      return this.createFailureResult("No messages found", 0, Date.now() - startTime);
+    }
 
-    return this.pick(response.content);
+    try {
+      const conversationJson = this.historyBuilder.buildHistoryFromDomain(messages);
+      const response = await this.assistantAgent.call({
+        conversationId: counsel.id.toString(),
+        message: this.getUserPrompt(conversationJson),
+        systemPrompt: this.getSystemPrompt(),
+        aiModel: AiModel.GPT_5,
+        temperature: 0,
+        maxToolCalls: 0,
+        useTools: false,
+      });
+
+      const updates = this.pick(response.content);
+      const processingTime = Date.now() - startTime;
+      const quality = this.assessQuality(updates, response.content);
+
+      return this.createResult(updates, messages.length, processingTime, quality);
+    } catch (error) {
+      return this.createFailureResult(
+        error instanceof Error ? error.message : "Unknown error",
+        messages.length,
+        Date.now() - startTime,
+      );
+    }
   }
 
   private getSystemPrompt(): string {

--- a/src/services/counselings/domains/counsels/context.organizer.ts
+++ b/src/services/counselings/domains/counsels/context.organizer.ts
@@ -18,16 +18,28 @@ export class ContextOrganizer {
   public organizeContext(counsel: Counsels): void {
     Promise.resolve()
       .then(async () => {
-        this.logger.log(`[ContextOrganizer] organizeContext: ${counsel.id.getString()}`);
-        const updates = await this.counselAnalyzer.analyze(counsel);
-        if (Object.keys(updates).length > 0) {
-          counsel.counselContexts.applyUpdates(updates);
+        this.logger.log(`organizeContext: ${counsel.id.getString()}`);
+        const analysisResult = await this.counselAnalyzer.analyze(counsel);
+
+        if (Object.keys(analysisResult.updates).length > 0) {
+          counsel.counselContexts.applyUpdates(analysisResult.updates);
           await this.counselsStore.update(counsel);
+
+          this.logger.log(
+            `Context updated: ${counsel.id.getString()}, ` +
+              `analyzers: ${analysisResult.analysisMetrics.successfulAnalyzers}/${analysisResult.analysisMetrics.totalAnalyzers}, ` +
+              `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
+          );
+        } else {
+          this.logger.debug(
+            `No updates needed: ${counsel.id.getString()}, ` +
+              `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
+          );
         }
         return;
       })
       .catch((error) => {
-        this.logger.error(`[ContextOrganizer] organizeContext failed: ${counsel.id.getString()}`, error);
+        this.logger.error(`organizeContext failed: ${counsel.id.getString()}`, error);
       });
   }
 }

--- a/src/services/counselings/domains/counsels/context.organizer.ts
+++ b/src/services/counselings/domains/counsels/context.organizer.ts
@@ -15,31 +15,30 @@ export class ContextOrganizer {
   private readonly logger = new Logger(ContextOrganizer.name);
 
   @Transactional({ propagation: Propagation.REQUIRES_NEW })
-  public organizeContext(counsel: Counsels): void {
-    Promise.resolve()
-      .then(async () => {
-        this.logger.log(`organizeContext: ${counsel.id.getString()}`);
-        const analysisResult = await this.counselAnalyzer.analyze(counsel);
+  public async organizeContext(counsel: Counsels): Promise<void> {
+    try {
+      this.logger.log(`organizeContext: ${counsel.id.getString()}`);
+      const analysisResult = await this.counselAnalyzer.analyze(counsel);
 
-        if (Object.keys(analysisResult.updates).length > 0) {
-          counsel.counselContexts.applyUpdates(analysisResult.updates);
-          await this.counselsStore.update(counsel);
+      if (Object.keys(analysisResult.updates).length > 0) {
+        counsel.counselContexts.applyUpdates(analysisResult.updates);
+        await this.counselsStore.update(counsel);
 
-          this.logger.log(
-            `Context updated: ${counsel.id.getString()}, ` +
-              `analyzers: ${analysisResult.analysisMetrics.successfulAnalyzers}/${analysisResult.analysisMetrics.totalAnalyzers}, ` +
-              `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
-          );
-        } else {
-          this.logger.debug(
-            `No updates needed: ${counsel.id.getString()}, ` +
-              `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
-          );
-        }
-        return;
-      })
-      .catch((error) => {
-        this.logger.error(`organizeContext failed: ${counsel.id.getString()}`, error);
-      });
+        this.logger.log(
+          `Context updated: ${counsel.id.getString()}, ` +
+            `analyzers: ${analysisResult.analysisMetrics.successfulAnalyzers}/${analysisResult.analysisMetrics.totalAnalyzers}, ` +
+            `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
+        );
+      } else {
+        this.logger.debug(
+          `No updates needed: ${counsel.id.getString()}, ` +
+            `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(`organizeContext failed: ${counsel.id.getString()}`, error);
+      // Transaction Rollback
+      throw error;
+    }
   }
 }

--- a/src/services/counselings/domains/counsels/context.organizer.ts
+++ b/src/services/counselings/domains/counsels/context.organizer.ts
@@ -1,6 +1,6 @@
 import { CounselAnalyzer } from "~counselings/domains/counsels/counsel.analyzer";
 import { CounselsStore } from "~counselings/domains/counsels/counsels.store";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts } from "~counselings/domains/counsels/models/counsel-contexts";
 
 import { Injectable, Logger } from "@nestjs/common";
 import { Propagation, Transactional } from "typeorm-transactional";
@@ -15,28 +15,28 @@ export class ContextOrganizer {
   private readonly logger = new Logger(ContextOrganizer.name);
 
   @Transactional({ propagation: Propagation.REQUIRES_NEW })
-  public async organizeContext(counsel: Counsels): Promise<void> {
+  public async organizeContext(counselContext: CounselContexts): Promise<void> {
     try {
-      this.logger.log(`organizeContext: ${counsel.id.getString()}`);
-      const analysisResult = await this.counselAnalyzer.analyze(counsel);
+      this.logger.log(`organizeContext: ${counselContext.counselId.getString()}`);
+      const analysisResult = await this.counselAnalyzer.analyze(counselContext);
 
       if (Object.keys(analysisResult.updates).length > 0) {
-        counsel.counselContexts.applyUpdates(analysisResult.updates);
-        await this.counselsStore.update(counsel);
+        counselContext.applyUpdates(analysisResult.updates);
+        await this.counselsStore.updateContexts(counselContext);
 
         this.logger.log(
-          `Context updated: ${counsel.id.getString()}, ` +
+          `Context updated: ${counselContext.counselId.getString()}, ` +
             `analyzers: ${analysisResult.analysisMetrics.successfulAnalyzers}/${analysisResult.analysisMetrics.totalAnalyzers}, ` +
             `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
         );
       } else {
         this.logger.debug(
-          `No updates needed: ${counsel.id.getString()}, ` +
+          `No updates needed: ${counselContext.counselId.getString()}, ` +
             `time: ${analysisResult.analysisMetrics.totalProcessingTime}ms`,
         );
       }
     } catch (error) {
-      this.logger.error(`organizeContext failed: ${counsel.id.getString()}`, error);
+      this.logger.error(`organizeContext failed: ${counselContext.counselId.getString()}`, error);
       // Transaction Rollback
       throw error;
     }

--- a/src/services/counselings/domains/counsels/counsel.analyzer.ts
+++ b/src/services/counselings/domains/counsels/counsel.analyzer.ts
@@ -3,8 +3,7 @@ import { ContextDomain } from "~counselings/domains/counsels/analyzers/context-d
 import { ContextReviewer } from "~counselings/domains/counsels/analyzers/context-reviewer";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
-import { CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 
 import { Inject, Injectable, Logger } from "@nestjs/common";
 
@@ -33,20 +32,20 @@ export class CounselAnalyzer {
    * 최근 대화 히스토리를 기반으로 counsel-context 후보 값을 추정한다.
    * 필요한 값만 반환하는 부분 업데이트 형태로 돌려준다.
    */
-  public async analyze(counsel: Counsels): Promise<CounselAnalysisResult> {
+  public async analyze(counselContext: CounselContexts): Promise<CounselAnalysisResult> {
     const startTime = Date.now();
 
     try {
       // 1) Light review to determine which domains to analyze
       const messages = await this.counselsReader.findManyMessages({
-        counselId: counsel.id,
+        counselId: counselContext.counselId,
         limit: 30,
         orderBy: { id: "DESC" },
       });
       const conversation = this.historyBuilder.buildHistoryFromDomain(messages);
 
       const review = await this.reviewer.review({
-        current: counsel.counselContexts,
+        current: counselContext,
         conversation,
       });
 
@@ -70,7 +69,7 @@ export class CounselAnalyzer {
         .map((d) => analyzerMap.get(d))
         .filter((x): x is BaseDomainAnalyzer => !!x)
         .map((a) =>
-          a.analyze(counsel).catch(
+          a.analyze(counselContext).catch(
             (error): AnalysisResult => ({
               updates: {},
               metadata: {
@@ -119,7 +118,7 @@ export class CounselAnalyzer {
         },
       };
     } catch (error) {
-      this.logger.warn(`Analyze failed for counsel ${counsel.id.getString()}: ${String(error)}`);
+      this.logger.warn(`Analyze failed for counsel ${counselContext.counselId.getString()}: ${String(error)}`);
       return {
         updates: {},
         analysisMetrics: {

--- a/src/services/counselings/domains/counsels/counsel.analyzer.ts
+++ b/src/services/counselings/domains/counsels/counsel.analyzer.ts
@@ -1,4 +1,4 @@
-import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
+import { AnalysisResult, BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import { ContextDomain } from "~counselings/domains/counsels/analyzers/context-domain.registry";
 import { ContextReviewer } from "~counselings/domains/counsels/analyzers/context-reviewer";
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
@@ -7,6 +7,16 @@ import { CounselContextsProps } from "~counselings/domains/counsels/models/couns
 import { Counsels } from "~counselings/domains/counsels/models/counsels";
 
 import { Inject, Injectable, Logger } from "@nestjs/common";
+
+export interface CounselAnalysisResult {
+  updates: Partial<CounselContextsProps>;
+  analysisMetrics: {
+    totalAnalyzers: number;
+    successfulAnalyzers: number;
+    averageProcessingTime: number;
+    totalProcessingTime: number;
+  };
+}
 
 @Injectable()
 export class CounselAnalyzer {
@@ -23,10 +33,11 @@ export class CounselAnalyzer {
    * 최근 대화 히스토리를 기반으로 counsel-context 후보 값을 추정한다.
    * 필요한 값만 반환하는 부분 업데이트 형태로 돌려준다.
    */
-  public async analyze(counsel: Counsels): Promise<Partial<CounselContextsProps>> {
+  public async analyze(counsel: Counsels): Promise<CounselAnalysisResult> {
+    const startTime = Date.now();
+
     try {
       // 1) Light review to determine which domains to analyze
-      // Build conversation JSON for reviewer
       const messages = await this.counselsReader.findManyMessages({
         counselId: counsel.id,
         limit: 30,
@@ -38,21 +49,86 @@ export class CounselAnalyzer {
         current: counsel.counselContexts,
         conversation,
       });
-      if (review.shouldAnalyzeDomains.length === 0) return {};
+
+      if (review.shouldAnalyzeDomains.length === 0) {
+        return {
+          updates: {},
+          analysisMetrics: {
+            totalAnalyzers: 0,
+            successfulAnalyzers: 0,
+            averageProcessingTime: 0,
+            totalProcessingTime: Date.now() - startTime,
+          },
+        };
+      }
 
       // 2) Run relevant analyzers in parallel
       const analyzerMap = new Map<ContextDomain, BaseDomainAnalyzer>();
       for (const a of this.analyzers) analyzerMap.set(a.domain, a);
+
       const tasks = review.shouldAnalyzeDomains
         .map((d) => analyzerMap.get(d))
         .filter((x): x is BaseDomainAnalyzer => !!x)
-        .map((a) => a.analyze(counsel).catch(() => ({})));
+        .map((a) =>
+          a.analyze(counsel).catch(
+            (error): AnalysisResult => ({
+              updates: {},
+              metadata: {
+                messageCount: 0,
+                processingTime: 0,
+                failureReason: String(error),
+                quality: "POOR",
+              },
+            }),
+          ),
+        );
+
+      if (tasks.length === 0) {
+        this.logger.warn(`No analyzers found for domains: ${review.shouldAnalyzeDomains.join(", ")}`);
+        return {
+          updates: {},
+          analysisMetrics: {
+            totalAnalyzers: 0,
+            successfulAnalyzers: 0,
+            averageProcessingTime: 0,
+            totalProcessingTime: Date.now() - startTime,
+          },
+        };
+      }
 
       const results = await Promise.all(tasks);
-      return Object.assign({}, ...results);
+
+      // 3) Aggregate results and metrics
+      const allUpdates = results.map((r) => r.updates);
+      const successfulResults = results.filter((r) => !r.metadata.failureReason);
+      const processingTimes = results.map((r) => r.metadata.processingTime);
+      const averageProcessingTime = processingTimes.reduce((sum, time) => sum + time, 0) / processingTimes.length;
+
+      this.logger.log(
+        `Analysis completed: ${successfulResults.length}/${results.length} successful, ` +
+          `avg time: ${averageProcessingTime.toFixed(1)}ms`,
+      );
+
+      return {
+        updates: Object.assign({}, ...allUpdates),
+        analysisMetrics: {
+          totalAnalyzers: results.length,
+          successfulAnalyzers: successfulResults.length,
+          averageProcessingTime,
+          totalProcessingTime: Date.now() - startTime,
+        },
+      };
     } catch (error) {
       this.logger.warn(`Analyze failed for counsel ${counsel.id.getString()}: ${String(error)}`);
-      return {};
+      return {
+        updates: {},
+        analysisMetrics: {
+          totalAnalyzers: 0,
+          successfulAnalyzers: 0,
+          averageProcessingTime: 0,
+          totalProcessingTime: Date.now() - startTime,
+        },
+      };
     }
   }
 }

--- a/src/services/counselings/domains/counsels/counsels.module.ts
+++ b/src/services/counselings/domains/counsels/counsels.module.ts
@@ -13,11 +13,15 @@ import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
 import { CounselsService } from "~counselings/domains/counsels/counsels.service";
 import { CounselsStore } from "~counselings/domains/counsels/counsels.store";
 import { CompressedMessagesRepository } from "~counselings/domains/counsels/infrastructures/compressed-messages.repository";
+import { CounselCompressConditionsRepository } from "~counselings/domains/counsels/infrastructures/counsel-compress-conditions.repository";
+import { CounselContextsRepository } from "~counselings/domains/counsels/infrastructures/counsel-contexts.repository";
 import { CounselMessagesRepository } from "~counselings/domains/counsels/infrastructures/counsel-messages.repository";
 import { CounselsRepository } from "~counselings/domains/counsels/infrastructures/counsels.repository";
 import { RepositoryCounselsReader } from "~counselings/domains/counsels/infrastructures/repository-counsels.reader";
 import { RepositoryCounselsStore } from "~counselings/domains/counsels/infrastructures/repository-counsels.store";
 import { TypeormCompressedMessagesRepository } from "~counselings/domains/counsels/infrastructures/typeorm-compressed-messages.repository";
+import { TypeormCounselCompressConditionsRepository } from "~counselings/domains/counsels/infrastructures/typeorm-counsel-compress-conditions.repository";
+import { TypeormCounselContextsRepository } from "~counselings/domains/counsels/infrastructures/typeorm-counsel-contexts.repository";
 import { TypeormCounselMessagesRepository } from "~counselings/domains/counsels/infrastructures/typeorm-counsel-messages.repository";
 import { TypeormCounselsRepository } from "~counselings/domains/counsels/infrastructures/typeorm-counsels.repository";
 import { MessageCompressor } from "~counselings/domains/counsels/message.compressor";
@@ -28,12 +32,19 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { AssistantAgentModule } from "~common/support/assistant-agents/assistant-agent.module";
 import { CompressedMessagesEntity } from "~common/system/persistences/entities/counsels/compressed-messages.entity";
 import { CounselsEntity } from "~common/system/persistences/entities/counsels/counsel.entity";
+import { CounselCompressConditionsEntity } from "~common/system/persistences/entities/counsels/counsel-compress-conditions.entity";
 import { CounselContextsEntity } from "~common/system/persistences/entities/counsels/counsel-contexts.entity";
 import { CounselMessagesEntity } from "~common/system/persistences/entities/counsels/counsel-messages.entity";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([CounselsEntity, CounselMessagesEntity, CounselContextsEntity, CompressedMessagesEntity]),
+    TypeOrmModule.forFeature([
+      CounselsEntity,
+      CounselMessagesEntity,
+      CounselContextsEntity,
+      CounselCompressConditionsEntity,
+      CompressedMessagesEntity,
+    ]),
     CounselingKafkaClientModule,
     AssistantAgentModule,
   ],
@@ -76,6 +87,14 @@ import { CounselMessagesEntity } from "~common/system/persistences/entities/coun
     {
       provide: CounselMessagesRepository,
       useClass: TypeormCounselMessagesRepository,
+    },
+    {
+      provide: CounselContextsRepository,
+      useClass: TypeormCounselContextsRepository,
+    },
+    {
+      provide: CounselCompressConditionsRepository,
+      useClass: TypeormCounselCompressConditionsRepository,
     },
     {
       provide: CompressedMessagesRepository,

--- a/src/services/counselings/domains/counsels/counsels.module.ts
+++ b/src/services/counselings/domains/counsels/counsels.module.ts
@@ -1,3 +1,4 @@
+import { AllianceAnalyzer } from "~counselings/domains/counsels/analyzers/alliance.analyzer";
 import { BaseDomainAnalyzer } from "~counselings/domains/counsels/analyzers/context-analyzer.interface";
 import { ContextReviewer } from "~counselings/domains/counsels/analyzers/context-reviewer";
 import { EmotionAnalyzer } from "~counselings/domains/counsels/analyzers/emotion.analyzer";
@@ -47,6 +48,7 @@ import { CounselMessagesEntity } from "~common/system/persistences/entities/coun
     MotivationAnalyzer,
     SupportSleepCognitiveAnalyzer,
     ImpactTimeframeAnalyzer,
+    AllianceAnalyzer,
     {
       provide: "CONTEXT_DOMAIN_ANALYZERS",
       useFactory: (
@@ -55,13 +57,15 @@ import { CounselMessagesEntity } from "~common/system/persistences/entities/coun
         motivation: MotivationAnalyzer,
         supportSleepCognitive: SupportSleepCognitiveAnalyzer,
         impactTimeframe: ImpactTimeframeAnalyzer,
-      ): BaseDomainAnalyzer[] => [emotion, risk, motivation, supportSleepCognitive, impactTimeframe],
+        alliance: AllianceAnalyzer,
+      ): BaseDomainAnalyzer[] => [emotion, risk, motivation, supportSleepCognitive, impactTimeframe, alliance],
       inject: [
         EmotionAnalyzer,
         RiskAnalyzer,
         MotivationAnalyzer,
         SupportSleepCognitiveAnalyzer,
         ImpactTimeframeAnalyzer,
+        AllianceAnalyzer,
       ],
     },
     ConversationHistoryBuilder,

--- a/src/services/counselings/domains/counsels/counsels.reader.ts
+++ b/src/services/counselings/domains/counsels/counsels.reader.ts
@@ -4,6 +4,8 @@ import {
   CounselsCriteriaFindMany,
 } from "~counselings/domains/counsels/counsels.criteria";
 import { CompressedMessages } from "~counselings/domains/counsels/models/compressed-messages";
+import { CounselCompressConditions } from "~counselings/domains/counsels/models/counsel-compress-conditions";
+import { CounselContexts } from "~counselings/domains/counsels/models/counsel-contexts";
 import { CounselMessages } from "~counselings/domains/counsels/models/counsel-messages";
 import { Counsels } from "~counselings/domains/counsels/models/counsels";
 
@@ -14,12 +16,23 @@ import { CounselMessageId } from "~common/shared-kernel/identifiers/counsel-mess
 
 @Injectable()
 export abstract class CounselsReader {
+  // Counsels 관련
   abstract findOne(props: { counselId: CounselId }): Promise<Counsels | null>;
   abstract findMany(props: CounselsCriteriaFindMany): Promise<Counsels[]>;
+
+  // CounselMessages 관련
   abstract findOneMessage(props: { counselMessageId: CounselMessageId }): Promise<CounselMessages | null>;
   abstract findManyMessages(props: CounselMessagesCriteriaFindMany): Promise<CounselMessages[]>;
+
+  // CompressedMessages 관련
   abstract findOneCompressedMessage(props: {
     compressedMessageId: CompressedMessageId;
   }): Promise<CompressedMessages | null>;
   abstract findManyCompressedMessages(props: CompressedMessagesCriteriaFindMany): Promise<CompressedMessages[]>;
+
+  // CounselCompressConditions 관련
+  abstract findCompressConditions(props: { counselId: CounselId }): Promise<CounselCompressConditions | null>;
+
+  // CounselContexts 관련
+  abstract findContexts(props: { counselId: CounselId }): Promise<CounselContexts | null>;
 }

--- a/src/services/counselings/domains/counsels/counsels.service.ts
+++ b/src/services/counselings/domains/counsels/counsels.service.ts
@@ -134,7 +134,7 @@ export class CounselsService {
     }
 
     // fire-and-forget: update counseling context while conversation continues
-    this.contextOrganizer.organizeContext(counsel);
+    if (!isUserMessage) this.contextOrganizer.organizeContext(counsel);
     return {
       counsel: CounselsInfo.fromDomain(counsel),
       message: CounselMessagesInfo.fromDomain(newMessage),

--- a/src/services/counselings/domains/counsels/counsels.service.ts
+++ b/src/services/counselings/domains/counsels/counsels.service.ts
@@ -8,7 +8,6 @@ import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
 import { CounselsStore } from "~counselings/domains/counsels/counsels.store";
 import { MessageCompressor } from "~counselings/domains/counsels/message.compressor";
 import { CompressedMessagesInfo } from "~counselings/domains/counsels/models/compressed-messages.info";
-import { CounselContextsInfo } from "~counselings/domains/counsels/models/counsel-contexts.info";
 import { CounselMessagesInfo } from "~counselings/domains/counsels/models/counsel-message.info";
 import { CounselsNewProps } from "~counselings/domains/counsels/models/counsels";
 import { CounselsInfo } from "~counselings/domains/counsels/models/counsels.info";
@@ -130,10 +129,6 @@ export class CounselsService {
     counsel.increaseMessageCount();
     await this.counselsStore.update(counsel);
 
-    if (counsel.counselContexts.shouldCompressContext()) {
-      this.messageCompressor.compressContext(counsel);
-    }
-
     return {
       counsel: CounselsInfo.fromDomain(counsel),
       message: CounselMessagesInfo.fromDomain(newMessage),
@@ -148,6 +143,16 @@ export class CounselsService {
       throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
     }
     await this.contextOrganizer.organizeContext(counsel);
+  }
+
+  // 조회 및 위임
+  async compressContext(props: { counselId: CounselId }): Promise<void> {
+    const { counselId } = props;
+    const counsel = await this.counselsReader.findOne({ counselId });
+    if (!counsel) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
+    }
+    await this.messageCompressor.compressContext(counsel);
   }
 
   @Transactional()

--- a/src/services/counselings/domains/counsels/counsels.service.ts
+++ b/src/services/counselings/domains/counsels/counsels.service.ts
@@ -8,6 +8,7 @@ import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
 import { CounselsStore } from "~counselings/domains/counsels/counsels.store";
 import { MessageCompressor } from "~counselings/domains/counsels/message.compressor";
 import { CompressedMessagesInfo } from "~counselings/domains/counsels/models/compressed-messages.info";
+import { CounselContextsInfo } from "~counselings/domains/counsels/models/counsel-contexts.info";
 import { CounselMessagesInfo } from "~counselings/domains/counsels/models/counsel-message.info";
 import { CounselsNewProps } from "~counselings/domains/counsels/models/counsels";
 import { CounselsInfo } from "~counselings/domains/counsels/models/counsels.info";
@@ -133,12 +134,20 @@ export class CounselsService {
       this.messageCompressor.compressContext(counsel);
     }
 
-    // fire-and-forget: update counseling context while conversation continues
-    if (!isUserMessage) this.contextOrganizer.organizeContext(counsel);
     return {
       counsel: CounselsInfo.fromDomain(counsel),
       message: CounselMessagesInfo.fromDomain(newMessage),
     };
+  }
+
+  // 조회 및 위임
+  async organizeContext(props: { counselId: CounselId }): Promise<void> {
+    const { counselId } = props;
+    const counsel = await this.counselsReader.findOne({ counselId });
+    if (!counsel) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
+    }
+    await this.contextOrganizer.organizeContext(counsel);
   }
 
   @Transactional()

--- a/src/services/counselings/domains/counsels/counsels.service.ts
+++ b/src/services/counselings/domains/counsels/counsels.service.ts
@@ -8,8 +8,9 @@ import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
 import { CounselsStore } from "~counselings/domains/counsels/counsels.store";
 import { MessageCompressor } from "~counselings/domains/counsels/message.compressor";
 import { CompressedMessagesInfo } from "~counselings/domains/counsels/models/compressed-messages.info";
+import { CounselCompressConditionsInfo } from "~counselings/domains/counsels/models/counsel-compress-conditions.info";
+import { CounselContextsInfo } from "~counselings/domains/counsels/models/counsel-contexts.info";
 import { CounselMessagesInfo } from "~counselings/domains/counsels/models/counsel-message.info";
-import { CounselsNewProps } from "~counselings/domains/counsels/models/counsels";
 import { CounselsInfo } from "~counselings/domains/counsels/models/counsels.info";
 import { CounselMessageReaction } from "~proto/com/hearlers/v1/model/counsel_pb";
 
@@ -17,6 +18,10 @@ import { HttpStatus, Injectable } from "@nestjs/common";
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
 import { CounselMessageId } from "~common/shared-kernel/identifiers/counsel-message.id";
 import { CounselTechniqueId } from "~common/shared-kernel/identifiers/counsel-techinque.id";
+import { CounselorId } from "~common/shared-kernel/identifiers/counselor.id";
+import { CounselorUserRelationshipId } from "~common/shared-kernel/identifiers/counselor-user-relationship.id";
+import { PromptVersionId } from "~common/shared-kernel/identifiers/prompt-version.id";
+import { UserId } from "~common/shared-kernel/identifiers/user.id";
 import { HttpStatusBasedRpcException } from "~common/system/filters/exceptions";
 import { Transactional } from "typeorm-transactional";
 
@@ -31,8 +36,27 @@ export class CounselsService {
   ) {}
 
   @Transactional()
-  async create(newProps: CounselsNewProps): Promise<CounselsInfo> {
-    const counsel = await this.counselsStore.create(newProps);
+  async initializeCounsel(props: {
+    userId: UserId;
+    counselorId: CounselorId;
+    promptVersionId: PromptVersionId;
+    counselorUserRelationshipId: CounselorUserRelationshipId;
+    counselTechniqueId: CounselTechniqueId;
+  }): Promise<CounselsInfo> {
+    const { userId, counselorId, promptVersionId, counselorUserRelationshipId, counselTechniqueId } = props;
+    const counsel = await this.counselsStore.create({
+      userId,
+      counselorId,
+      promptVersionId,
+      counselorUserRelationshipId,
+    });
+    await this.counselsStore.createContexts({
+      counselId: counsel.id,
+      counselTechniqueId,
+    });
+    await this.counselsStore.createCompressConditions({
+      counselId: counsel.id,
+    });
     return CounselsInfo.fromDomain(counsel);
   }
 
@@ -44,6 +68,22 @@ export class CounselsService {
     return CounselsInfo.fromDomain(counsel);
   }
 
+  async getContext(props: { counselId: CounselId }): Promise<CounselContextsInfo> {
+    const context = await this.counselsReader.findContexts(props);
+    if (!context) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel context not found");
+    }
+    return CounselContextsInfo.fromDomain(context);
+  }
+
+  async getCompressCondition(props: { counselId: CounselId }): Promise<CounselCompressConditionsInfo> {
+    const condition = await this.counselsReader.findCompressConditions(props);
+    if (!condition) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel compress condition not found");
+    }
+    return CounselCompressConditionsInfo.fromDomain(condition);
+  }
+
   async getMessages(criteria: CounselMessagesCriteriaFindMany): Promise<CounselMessagesInfo[]> {
     const messages = await this.counselsReader.findManyMessages(criteria);
     return CounselMessagesInfo.fromDomainArray(messages);
@@ -53,14 +93,24 @@ export class CounselsService {
     counsel: CounselsInfo;
     messages: CounselMessagesInfo[];
     compressedMessages: CompressedMessagesInfo[];
+    counselContext: CounselContextsInfo;
+    compressCondition: CounselCompressConditionsInfo;
   }> {
     const counsel = await this.counselsReader.findOne(props);
     if (!counsel) {
       throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
     }
+    const counselContext = await this.counselsReader.findContexts(props);
+    if (!counselContext) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel context not found");
+    }
+    const compressCondition = await this.counselsReader.findCompressConditions(props);
+    if (!compressCondition) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel compress condition not found");
+    }
     const messages = await this.counselsReader.findManyMessages({
       counselId: props.counselId,
-      limit: counsel.counselContexts.notCompressedMessageCount,
+      limit: counsel.messageCount - compressCondition.messageCountAtLastCompression,
     });
     const compressedMessages = await this.counselsReader.findManyCompressedMessages({ counselId: props.counselId });
 
@@ -68,6 +118,8 @@ export class CounselsService {
       counsel: CounselsInfo.fromDomain(counsel),
       messages: CounselMessagesInfo.fromDomainArray(messages),
       compressedMessages: CompressedMessagesInfo.fromDomainArray(compressedMessages),
+      counselContext: CounselContextsInfo.fromDomain(counselContext),
+      compressCondition: CounselCompressConditionsInfo.fromDomain(compressCondition),
     };
   }
 
@@ -93,17 +145,17 @@ export class CounselsService {
   async updateCounselTechniqueId(props: {
     counselId: CounselId;
     counselTechniqueId: CounselTechniqueId;
-  }): Promise<CounselsInfo> {
-    const { counselId, counselTechniqueId } = props;
-    const counsel = await this.counselsReader.findOne({ counselId });
-    if (!counsel) {
-      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
+    currentMessageCount: number;
+  }): Promise<void> {
+    const { counselId, counselTechniqueId, currentMessageCount } = props;
+    const counselContext = await this.counselsReader.findContexts({ counselId });
+    if (!counselContext) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel context not found");
     }
 
-    counsel.updateCounselTechniqueId(counselTechniqueId);
+    counselContext.updateCounselTechniqueId(counselTechniqueId, currentMessageCount);
 
-    const updatedCounsel = await this.counselsStore.update(counsel);
-    return CounselsInfo.fromDomain(updatedCounsel);
+    await this.counselsStore.updateContexts(counselContext);
   }
 
   @Transactional()
@@ -117,12 +169,16 @@ export class CounselsService {
     if (!counsel) {
       throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
     }
+    const counselContext = await this.counselsReader.findContexts({ counselId });
+    if (!counselContext) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel context not found");
+    }
     const newMessage = await this.counselsStore.createMessage({
       counselId,
       message,
       isUserMessage,
       userId: counsel.userId,
-      counselTechniqueId: counsel.counselTechniqueId,
+      counselTechniqueId: counselContext.counselTechniqueId,
     });
 
     counsel.saveLastMessage(message);
@@ -138,11 +194,11 @@ export class CounselsService {
   // 조회 및 위임
   async organizeContext(props: { counselId: CounselId }): Promise<void> {
     const { counselId } = props;
-    const counsel = await this.counselsReader.findOne({ counselId });
-    if (!counsel) {
-      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
+    const counselContext = await this.counselsReader.findContexts({ counselId });
+    if (!counselContext) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel context not found");
     }
-    await this.contextOrganizer.organizeContext(counsel);
+    await this.contextOrganizer.organizeContext(counselContext);
   }
 
   // 조회 및 위임
@@ -152,7 +208,14 @@ export class CounselsService {
     if (!counsel) {
       throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel not found");
     }
-    await this.messageCompressor.compressContext(counsel);
+    const counselCompressConditions = await this.counselsReader.findCompressConditions({ counselId });
+    if (!counselCompressConditions) {
+      throw new HttpStatusBasedRpcException(HttpStatus.NOT_FOUND, "Counsel compress condition not found");
+    }
+    const currentMessageCount = counsel.messageCount;
+    if (counselCompressConditions.shouldCompressContext(currentMessageCount)) {
+      await this.messageCompressor.compressContext(counselCompressConditions, currentMessageCount);
+    }
   }
 
   @Transactional()

--- a/src/services/counselings/domains/counsels/counsels.store.ts
+++ b/src/services/counselings/domains/counsels/counsels.store.ts
@@ -2,6 +2,11 @@ import {
   CompressedMessages,
   CompressedMessagesNewProps,
 } from "~counselings/domains/counsels/models/compressed-messages";
+import {
+  CounselCompressConditions,
+  CounselCompressConditionsNewProps,
+} from "~counselings/domains/counsels/models/counsel-compress-conditions";
+import { CounselContexts, CounselContextsNewProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { CounselMessages, CounselMessagesNewProps } from "~counselings/domains/counsels/models/counsel-messages";
 import { Counsels, CounselsNewProps } from "~counselings/domains/counsels/models/counsels";
 
@@ -9,13 +14,26 @@ import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export abstract class CounselsStore {
+  // Counsels 관련
   abstract create(newProps: CounselsNewProps): Promise<Counsels>;
   abstract update(counsel: Counsels): Promise<Counsels>;
   abstract updateMany(counsels: Counsels[]): Promise<Counsels[]>;
+
+  // CounselMessages 관련
   abstract createMessage(newProps: CounselMessagesNewProps): Promise<CounselMessages>;
   abstract updateMessage(counselMessage: CounselMessages): Promise<CounselMessages>;
   abstract updateManyMessages(counselMessages: CounselMessages[]): Promise<CounselMessages[]>;
+
+  // CompressedMessages 관련
   abstract createCompressedMessage(newProps: CompressedMessagesNewProps): Promise<CompressedMessages>;
   abstract updateCompressedMessage(compressedMessage: CompressedMessages): Promise<CompressedMessages>;
   abstract updateManyCompressedMessages(compressedMessages: CompressedMessages[]): Promise<CompressedMessages[]>;
+
+  // CounselCompressConditions 관련
+  abstract createCompressConditions(newProps: CounselCompressConditionsNewProps): Promise<CounselCompressConditions>;
+  abstract updateCompressConditions(compressConditions: CounselCompressConditions): Promise<CounselCompressConditions>;
+
+  // CounselContexts 관련
+  abstract createContexts(newProps: CounselContextsNewProps): Promise<CounselContexts>;
+  abstract updateContexts(contexts: CounselContexts): Promise<CounselContexts>;
 }

--- a/src/services/counselings/domains/counsels/infrastructures/counsel-compress-conditions.repository.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/counsel-compress-conditions.repository.ts
@@ -1,0 +1,11 @@
+import { CounselCompressConditions } from "~counselings/domains/counsels/models/counsel-compress-conditions";
+
+import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { CounselCompressConditionId } from "~common/shared-kernel/identifiers/counsel-compress-condition.id";
+
+export abstract class CounselCompressConditionsRepository {
+  abstract findById(compressConditionId: CounselCompressConditionId): Promise<CounselCompressConditions | null>;
+  abstract findByCounselId(counselId: CounselId): Promise<CounselCompressConditions | null>;
+  abstract save(compressCondition: CounselCompressConditions): Promise<CounselCompressConditions>;
+  abstract save(compressConditions: CounselCompressConditions[]): Promise<CounselCompressConditions[]>;
+}

--- a/src/services/counselings/domains/counsels/infrastructures/counsel-contexts.repository.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/counsel-contexts.repository.ts
@@ -1,0 +1,12 @@
+import { CounselContexts } from "~counselings/domains/counsels/models/counsel-contexts";
+
+import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { CounselContextId } from "~common/shared-kernel/identifiers/counsel-context.id";
+import { FindManyOptions, Repository } from "typeorm";
+
+export abstract class CounselContextsRepository {
+  abstract findById(counselContextId: CounselContextId): Promise<CounselContexts | null>;
+  abstract findByCounselId(counselId: CounselId): Promise<CounselContexts | null>;
+  abstract save(counselContext: CounselContexts): Promise<CounselContexts>;
+  abstract save(counselContexts: CounselContexts[]): Promise<CounselContexts[]>;
+}

--- a/src/services/counselings/domains/counsels/infrastructures/mappers/typeorm-counsel-compress-conditions.mapper.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/mappers/typeorm-counsel-compress-conditions.mapper.ts
@@ -1,0 +1,40 @@
+import { CounselCompressConditions } from "~counselings/domains/counsels/models/counsel-compress-conditions";
+
+import { convertDayjs } from "~common/shared/utils/date";
+import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { CounselCompressConditionId } from "~common/shared-kernel/identifiers/counsel-compress-condition.id";
+import { CounselCompressConditionsEntity } from "~common/system/persistences/entities/counsels/counsel-compress-conditions.entity";
+
+export class TypeormCounselCompressConditionsMapper {
+  static toDomain(entity: CounselCompressConditionsEntity): CounselCompressConditions {
+    const result = CounselCompressConditions.create(
+      {
+        counselId: new CounselId(entity.counselId),
+        messageCountAtLastCompression: entity.messageCountAtLastCompression,
+        lastMessageCompressedAt: entity.lastMessageCompressedAt ? convertDayjs(entity.lastMessageCompressedAt) : null,
+        createdAt: convertDayjs(entity.createdAt),
+        updatedAt: convertDayjs(entity.updatedAt),
+        deletedAt: entity.deletedAt ? convertDayjs(entity.deletedAt) : null,
+      },
+      new CounselCompressConditionId(entity.id),
+    );
+
+    if (result.isFailure) {
+      throw new Error(`Failed to create CounselCompressConditions domain: ${result.error}`);
+    }
+
+    return result.value;
+  }
+
+  static toEntity(domain: CounselCompressConditions): CounselCompressConditionsEntity {
+    const entity = new CounselCompressConditionsEntity();
+    entity.id = domain.id.getString();
+    entity.counselId = domain.counselId.getString();
+    entity.messageCountAtLastCompression = domain.messageCountAtLastCompression;
+    entity.lastMessageCompressedAt = domain.lastMessageCompressedAt?.toISOString() || null;
+    entity.createdAt = domain.createdAt.toISOString();
+    entity.updatedAt = domain.updatedAt.toISOString();
+    entity.deletedAt = domain.deletedAt ? domain.deletedAt.toISOString() : null;
+    return entity;
+  }
+}

--- a/src/services/counselings/domains/counsels/infrastructures/mappers/typeorm-counsel-contexts.mapper.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/mappers/typeorm-counsel-contexts.mapper.ts
@@ -1,11 +1,12 @@
 import { CounselContexts, CounselContextsProps } from "~counselings/domains/counsels/models/counsel-contexts";
 
 import { HttpStatus } from "@nestjs/common";
+import { convertDayjs } from "~common/shared/utils/date";
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
 import { CounselContextId } from "~common/shared-kernel/identifiers/counsel-context.id";
+import { CounselTechniqueId } from "~common/shared-kernel/identifiers/counsel-techinque.id";
 import { HttpStatusBasedRpcException } from "~common/system/filters/exceptions";
 import { CounselContextsEntity } from "~common/system/persistences/entities/counsels/counsel-contexts.entity";
-import dayjs from "dayjs";
 
 export class TypeormCounselContextsMapper {
   static toDomain(entity: null): null;
@@ -18,9 +19,8 @@ export class TypeormCounselContextsMapper {
 
     const counselContextsProps: CounselContextsProps = {
       counselId: new CounselId(entity.counselId),
-      notCompressedMessageCount: entity.notCompressedMessageCount,
-      lastMessageCompressedAt: entity.lastMessageCompressedAt ? dayjs(entity.lastMessageCompressedAt) : null,
-      currentTechniqueMessageCount: entity.currentTechniqueMessageCount,
+      counselTechniqueId: new CounselTechniqueId(entity.counselTechniqueId),
+      messageCountAtLastTransition: entity.messageCountAtLastTransition,
       impactDomain: entity.impactDomain,
       timeframe: entity.timeframe,
       emotionPrimary: entity.emotionPrimary,
@@ -38,9 +38,9 @@ export class TypeormCounselContextsMapper {
       emotionIntensity: entity.emotionIntensity,
       physicalSymptomsPresent: entity.physicalSymptomsPresent,
       consentToDepth: entity.consentToDepth,
-      createdAt: dayjs(entity.createdAt),
-      updatedAt: dayjs(entity.updatedAt),
-      deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
+      createdAt: convertDayjs(entity.createdAt),
+      updatedAt: convertDayjs(entity.updatedAt),
+      deletedAt: entity.deletedAt ? convertDayjs(entity.deletedAt) : null,
     };
     const counselsOrError = CounselContexts.create(counselContextsProps, new CounselContextId(entity.id));
 
@@ -60,11 +60,8 @@ export class TypeormCounselContextsMapper {
 
     entity.id = counselContexts.id.getString();
     entity.counselId = counselContexts.counselId.getString();
-    entity.notCompressedMessageCount = counselContexts.notCompressedMessageCount;
-    entity.lastMessageCompressedAt = counselContexts.lastMessageCompressedAt
-      ? counselContexts.lastMessageCompressedAt.toISOString()
-      : null;
-    entity.currentTechniqueMessageCount = counselContexts.currentTechniqueMessageCount;
+    entity.counselTechniqueId = counselContexts.counselTechniqueId.getString();
+    entity.messageCountAtLastTransition = counselContexts.messageCountAtLastTransition;
     entity.impactDomain = counselContexts.impactDomain;
     entity.timeframe = counselContexts.timeframe;
     entity.emotionPrimary = counselContexts.emotionPrimary;

--- a/src/services/counselings/domains/counsels/infrastructures/mappers/typeorm-counsels.mapper.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/mappers/typeorm-counsels.mapper.ts
@@ -3,7 +3,6 @@ import { Counsels, CounselsProps } from "~counselings/domains/counsels/models/co
 
 import { HttpStatus } from "@nestjs/common";
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
-import { CounselTechniqueId } from "~common/shared-kernel/identifiers/counsel-techinque.id";
 import { CounselorId } from "~common/shared-kernel/identifiers/counselor.id";
 import { CounselorUserRelationshipId } from "~common/shared-kernel/identifiers/counselor-user-relationship.id";
 import { PromptVersionId } from "~common/shared-kernel/identifiers/prompt-version.id";
@@ -24,7 +23,6 @@ export class TypeormCounselsMapper {
     const counselProps: CounselsProps = {
       userId: new UserId(entity.userId),
       counselorId: new CounselorId(entity.counselorId),
-      counselTechniqueId: new CounselTechniqueId(entity.counselTechniqueId),
       promptVersionId: new PromptVersionId(entity.promptVersionId),
       counselorUserRelationshipId: new CounselorUserRelationshipId(entity.counselorUserRelationshipId),
       lastChatedAt: entity.lastChatedAt ? dayjs(entity.lastChatedAt) : null,
@@ -33,7 +31,6 @@ export class TypeormCounselsMapper {
       createdAt: dayjs(entity.createdAt),
       updatedAt: dayjs(entity.updatedAt),
       deletedAt: entity.deletedAt ? dayjs(entity.deletedAt) : null,
-      counselContexts: TypeormCounselContextsMapper.toDomain(entity.counselContext),
     };
     const counselsOrError = Counsels.create(counselProps, new CounselId(entity.id));
 
@@ -54,7 +51,6 @@ export class TypeormCounselsMapper {
     entity.id = counsels.id.getString();
     entity.userId = counsels.userId.getString();
     entity.counselorId = counsels.counselorId.getString();
-    entity.counselTechniqueId = counsels.counselTechniqueId.getString();
     entity.promptVersionId = counsels.promptVersionId.getString();
     entity.counselorUserRelationshipId = counsels.counselorUserRelationshipId.getString();
 
@@ -66,8 +62,6 @@ export class TypeormCounselsMapper {
     entity.createdAt = counsels.createdAt.toISOString();
     entity.updatedAt = counsels.updatedAt.toISOString();
     entity.deletedAt = counsels.deletedAt ? counsels.deletedAt.toISOString() : null;
-
-    entity.counselContext = TypeormCounselContextsMapper.toEntity(counsels.counselContexts);
 
     return entity;
   }

--- a/src/services/counselings/domains/counsels/infrastructures/repository-counsels.reader.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/repository-counsels.reader.ts
@@ -5,10 +5,14 @@ import {
 } from "~counselings/domains/counsels/counsels.criteria";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
 import { CompressedMessagesRepository } from "~counselings/domains/counsels/infrastructures/compressed-messages.repository";
+import { CounselCompressConditionsRepository } from "~counselings/domains/counsels/infrastructures/counsel-compress-conditions.repository";
+import { CounselContextsRepository } from "~counselings/domains/counsels/infrastructures/counsel-contexts.repository";
 import { CounselMessagesRepository } from "~counselings/domains/counsels/infrastructures/counsel-messages.repository";
 import { CounselsRepository } from "~counselings/domains/counsels/infrastructures/counsels.repository";
 import { RepositoryCounselCriteriaMapper } from "~counselings/domains/counsels/infrastructures/mappers/repository-counsels-criteria.mapper";
 import { CompressedMessages } from "~counselings/domains/counsels/models/compressed-messages";
+import { CounselCompressConditions } from "~counselings/domains/counsels/models/counsel-compress-conditions";
+import { CounselContexts } from "~counselings/domains/counsels/models/counsel-contexts";
 import { CounselMessages } from "~counselings/domains/counsels/models/counsel-messages";
 import { Counsels } from "~counselings/domains/counsels/models/counsels";
 
@@ -23,6 +27,8 @@ export class RepositoryCounselsReader extends CounselsReader {
     private readonly counselsRepository: CounselsRepository,
     private readonly counselMessagesRepository: CounselMessagesRepository,
     private readonly compressedMessagesRepository: CompressedMessagesRepository,
+    private readonly counselCompressConditionsRepository: CounselCompressConditionsRepository,
+    private readonly counselContextsRepository: CounselContextsRepository,
   ) {
     super();
   }
@@ -54,5 +60,13 @@ export class RepositoryCounselsReader extends CounselsReader {
   override async findManyCompressedMessages(props: CompressedMessagesCriteriaFindMany): Promise<CompressedMessages[]> {
     const typeormOptions = RepositoryCounselCriteriaMapper.toFindManyCompressedMessageOptions(props);
     return this.compressedMessagesRepository.findMany(typeormOptions);
+  }
+
+  override async findCompressConditions(props: { counselId: CounselId }): Promise<CounselCompressConditions | null> {
+    return this.counselCompressConditionsRepository.findByCounselId(props.counselId);
+  }
+
+  override async findContexts(props: { counselId: CounselId }): Promise<CounselContexts | null> {
+    return this.counselContextsRepository.findByCounselId(props.counselId);
   }
 }

--- a/src/services/counselings/domains/counsels/infrastructures/repository-counsels.store.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/repository-counsels.store.ts
@@ -1,11 +1,18 @@
 import { CounselsStore } from "~counselings/domains/counsels/counsels.store";
 import { CompressedMessagesRepository } from "~counselings/domains/counsels/infrastructures/compressed-messages.repository";
+import { CounselCompressConditionsRepository } from "~counselings/domains/counsels/infrastructures/counsel-compress-conditions.repository";
+import { CounselContextsRepository } from "~counselings/domains/counsels/infrastructures/counsel-contexts.repository";
 import { CounselMessagesRepository } from "~counselings/domains/counsels/infrastructures/counsel-messages.repository";
 import { CounselsRepository } from "~counselings/domains/counsels/infrastructures/counsels.repository";
 import {
   CompressedMessages,
   CompressedMessagesNewProps,
 } from "~counselings/domains/counsels/models/compressed-messages";
+import {
+  CounselCompressConditions,
+  CounselCompressConditionsNewProps,
+} from "~counselings/domains/counsels/models/counsel-compress-conditions";
+import { CounselContexts, CounselContextsNewProps } from "~counselings/domains/counsels/models/counsel-contexts";
 import { CounselMessages, CounselMessagesNewProps } from "~counselings/domains/counsels/models/counsel-messages";
 import { Counsels, CounselsNewProps } from "~counselings/domains/counsels/models/counsels";
 
@@ -18,6 +25,8 @@ export class RepositoryCounselsStore extends CounselsStore {
     private readonly counselRepository: CounselsRepository,
     private readonly counselMessagesRepository: CounselMessagesRepository,
     private readonly compressedMessagesRepository: CompressedMessagesRepository,
+    private readonly counselCompressConditionsRepository: CounselCompressConditionsRepository,
+    private readonly counselContextsRepository: CounselContextsRepository,
   ) {
     super();
   }
@@ -68,5 +77,33 @@ export class RepositoryCounselsStore extends CounselsStore {
 
   override async updateManyCompressedMessages(compressedMessages: CompressedMessages[]): Promise<CompressedMessages[]> {
     return this.compressedMessagesRepository.save(compressedMessages);
+  }
+
+  override async createCompressConditions(
+    newProps: CounselCompressConditionsNewProps,
+  ): Promise<CounselCompressConditions> {
+    const compressConditionsResult = CounselCompressConditions.createNew(newProps);
+    if (compressConditionsResult.isFailure) {
+      throw new HttpStatusBasedRpcException(HttpStatus.BAD_REQUEST, compressConditionsResult.error as string);
+    }
+    return this.counselCompressConditionsRepository.save(compressConditionsResult.value);
+  }
+
+  override async updateCompressConditions(
+    compressConditions: CounselCompressConditions,
+  ): Promise<CounselCompressConditions> {
+    return this.counselCompressConditionsRepository.save(compressConditions);
+  }
+
+  override async createContexts(newProps: CounselContextsNewProps): Promise<CounselContexts> {
+    const contextsResult = CounselContexts.createNew(newProps);
+    if (contextsResult.isFailure) {
+      throw new HttpStatusBasedRpcException(HttpStatus.BAD_REQUEST, contextsResult.error as string);
+    }
+    return this.counselContextsRepository.save(contextsResult.value);
+  }
+
+  override async updateContexts(contexts: CounselContexts): Promise<CounselContexts> {
+    return this.counselContextsRepository.save(contexts);
   }
 }

--- a/src/services/counselings/domains/counsels/infrastructures/typeorm-counsel-compress-conditions.repository.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/typeorm-counsel-compress-conditions.repository.ts
@@ -1,0 +1,52 @@
+import { CounselCompressConditionsRepository } from "~counselings/domains/counsels/infrastructures/counsel-compress-conditions.repository";
+import { TypeormCounselCompressConditionsMapper } from "~counselings/domains/counsels/infrastructures/mappers/typeorm-counsel-compress-conditions.mapper";
+import { CounselCompressConditions } from "~counselings/domains/counsels/models/counsel-compress-conditions";
+
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { CounselCompressConditionId } from "~common/shared-kernel/identifiers/counsel-compress-condition.id";
+import { CounselCompressConditionsEntity } from "~common/system/persistences/entities/counsels/counsel-compress-conditions.entity";
+import { Repository } from "typeorm";
+
+@Injectable()
+export class TypeormCounselCompressConditionsRepository extends CounselCompressConditionsRepository {
+  constructor(
+    @InjectRepository(CounselCompressConditionsEntity)
+    private readonly compressConditionsEntity: Repository<CounselCompressConditionsEntity>,
+  ) {
+    super();
+  }
+
+  async save(compressCondition: CounselCompressConditions): Promise<CounselCompressConditions>;
+  async save(compressConditions: CounselCompressConditions[]): Promise<CounselCompressConditions[]>;
+  async save(
+    compressConditions: CounselCompressConditions | CounselCompressConditions[],
+  ): Promise<CounselCompressConditions | CounselCompressConditions[]> {
+    if (Array.isArray(compressConditions)) {
+      const entities = compressConditions.map((condition) =>
+        TypeormCounselCompressConditionsMapper.toEntity(condition),
+      );
+      const savedEntities = await this.compressConditionsEntity.save(entities);
+      return savedEntities.map((entity) => TypeormCounselCompressConditionsMapper.toDomain(entity));
+    } else {
+      const entity = TypeormCounselCompressConditionsMapper.toEntity(compressConditions);
+      const savedEntity = await this.compressConditionsEntity.save(entity);
+      return TypeormCounselCompressConditionsMapper.toDomain(savedEntity);
+    }
+  }
+
+  async findById(compressConditionId: CounselCompressConditionId): Promise<CounselCompressConditions | null> {
+    const entity = await this.compressConditionsEntity.findOne({
+      where: { id: compressConditionId.getString() },
+    });
+    return entity ? TypeormCounselCompressConditionsMapper.toDomain(entity) : null;
+  }
+
+  async findByCounselId(counselId: CounselId): Promise<CounselCompressConditions | null> {
+    const entity = await this.compressConditionsEntity.findOne({
+      where: { counselId: counselId.getString() },
+    });
+    return entity ? TypeormCounselCompressConditionsMapper.toDomain(entity) : null;
+  }
+}

--- a/src/services/counselings/domains/counsels/infrastructures/typeorm-counsel-contexts.repository.ts
+++ b/src/services/counselings/domains/counsels/infrastructures/typeorm-counsel-contexts.repository.ts
@@ -1,0 +1,48 @@
+import { CounselContextsRepository } from "~counselings/domains/counsels/infrastructures/counsel-contexts.repository";
+import { TypeormCounselContextsMapper } from "~counselings/domains/counsels/infrastructures/mappers/typeorm-counsel-contexts.mapper";
+import { CounselContexts } from "~counselings/domains/counsels/models/counsel-contexts";
+
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { CounselContextId } from "~common/shared-kernel/identifiers/counsel-context.id";
+import { CounselContextsEntity } from "~common/system/persistences/entities/counsels/counsel-contexts.entity";
+import { Repository } from "typeorm";
+
+@Injectable()
+export class TypeormCounselContextsRepository extends CounselContextsRepository {
+  constructor(
+    @InjectRepository(CounselContextsEntity)
+    private readonly counselContextsEntity: Repository<CounselContextsEntity>,
+  ) {
+    super();
+  }
+
+  async save(counselContext: CounselContexts): Promise<CounselContexts>;
+  async save(counselContexts: CounselContexts[]): Promise<CounselContexts[]>;
+  async save(counselContexts: CounselContexts | CounselContexts[]): Promise<CounselContexts | CounselContexts[]> {
+    if (Array.isArray(counselContexts)) {
+      const entities = counselContexts.map((context) => TypeormCounselContextsMapper.toEntity(context));
+      const savedEntities = await this.counselContextsEntity.save(entities);
+      return savedEntities.map((entity) => TypeormCounselContextsMapper.toDomain(entity));
+    } else {
+      const entity = TypeormCounselContextsMapper.toEntity(counselContexts);
+      const savedEntity = await this.counselContextsEntity.save(entity);
+      return TypeormCounselContextsMapper.toDomain(savedEntity);
+    }
+  }
+
+  async findById(counselContextId: CounselContextId): Promise<CounselContexts | null> {
+    const entity = await this.counselContextsEntity.findOne({
+      where: { id: counselContextId.getString() },
+    });
+    return entity ? TypeormCounselContextsMapper.toDomain(entity) : null;
+  }
+
+  async findByCounselId(counselId: CounselId): Promise<CounselContexts | null> {
+    const entity = await this.counselContextsEntity.findOne({
+      where: { counselId: counselId.getString() },
+    });
+    return entity ? TypeormCounselContextsMapper.toDomain(entity) : null;
+  }
+}

--- a/src/services/counselings/domains/counsels/message.compressor.ts
+++ b/src/services/counselings/domains/counsels/message.compressor.ts
@@ -1,8 +1,7 @@
 import { ConversationHistoryBuilder } from "~counselings/domains/counsels/conversation-history.builder";
 import { CounselsReader } from "~counselings/domains/counsels/counsels.reader";
 import { CounselsStore } from "~counselings/domains/counsels/counsels.store";
-import { CounselContexts } from "~counselings/domains/counsels/models/counsel-contexts";
-import { Counsels } from "~counselings/domains/counsels/models/counsels";
+import { CounselCompressConditions } from "~counselings/domains/counsels/models/counsel-compress-conditions";
 import { AiModel } from "~proto/com/hearlers/v1/model/counsel_prompt_pb";
 
 import { Inject, Injectable, Logger } from "@nestjs/common";
@@ -23,31 +22,40 @@ export class MessageCompressor {
   private readonly logger = new Logger(MessageCompressor.name);
 
   @Transactional({ propagation: Propagation.REQUIRES_NEW })
-  public async compressContext(counsel: Counsels): Promise<void> {
+  public async compressContext(
+    compressCondition: CounselCompressConditions,
+    currentMessageCount: number,
+  ): Promise<void> {
     try {
-      this.logger.log(`[MessageCompressor] compressContext: ${counsel.id.getString()}`);
-      const compressedMessageContent = await this.generateCompressedMessage(counsel);
+      this.logger.log(`[MessageCompressor] compressContext: ${compressCondition.counselId.getString()}`);
+      const compressedMessageContent = await this.generateCompressedMessage(compressCondition, currentMessageCount);
       const compressedMessage = await this.counselsStore.createCompressedMessage({
-        counselId: counsel.id,
+        counselId: compressCondition.counselId,
         content: compressedMessageContent,
-        messageCountAtCompression: counsel.messageCount,
+        messageCountAtCompression: currentMessageCount,
       });
-      counsel.counselContexts.markContextCompressed();
-      await this.counselsStore.update(counsel);
+      compressCondition.markContextCompressed(currentMessageCount);
+      await this.counselsStore.updateCompressConditions(compressCondition);
 
       this.logger.log(
-        `[MessageCompressor] Compressed message created: ${compressedMessage.id.getString()} for counsel: ${counsel.id.getString()}`,
+        `[MessageCompressor] Compressed message created: ${compressedMessage.id.getString()} for counsel: ${compressCondition.counselId.getString()}`,
       );
     } catch (error) {
-      this.logger.error(`[MessageCompressor] compressContext failed: ${counsel.id.getString()}`, error);
+      this.logger.error(
+        `[MessageCompressor] compressContext failed: ${compressCondition.counselId.getString()}`,
+        error,
+      );
       throw error;
     }
   }
 
-  private async generateCompressedMessage(counsel: Counsels): Promise<string> {
+  private async generateCompressedMessage(
+    compressCondition: CounselCompressConditions,
+    currentMessageCount: number,
+  ): Promise<string> {
     const messages = await this.counselsReader.findManyMessages({
-      counselId: counsel.id,
-      limit: CounselContexts.COMPRESSION_THRESHOLD,
+      counselId: compressCondition.counselId,
+      limit: currentMessageCount - compressCondition.messageCountAtLastCompression,
       offset: 0,
       orderBy: {
         id: "DESC",
@@ -58,7 +66,7 @@ export class MessageCompressor {
     const userPrompt = this.getUserPrompt(conversationJson);
 
     const response = await this.assistantAgent.call({
-      conversationId: counsel.id.toString(),
+      conversationId: compressCondition.counselId.toString(),
       message: userPrompt,
       systemPrompt,
       aiModel: AiModel.GPT_5,

--- a/src/services/counselings/domains/counsels/message.compressor.ts
+++ b/src/services/counselings/domains/counsels/message.compressor.ts
@@ -23,24 +23,25 @@ export class MessageCompressor {
   private readonly logger = new Logger(MessageCompressor.name);
 
   @Transactional({ propagation: Propagation.REQUIRES_NEW })
-  public compressContext(counsel: Counsels): void {
-    Promise.resolve()
-      .then(async () => {
-        this.logger.log(`[MessageCompressor] compressContext: ${counsel.id.getString()}`);
-        const compressedMessageContent = await this.generateCompressedMessage(counsel);
-        const compressedMessage = await this.counselsStore.createCompressedMessage({
-          counselId: counsel.id,
-          content: compressedMessageContent,
-          messageCountAtCompression: counsel.messageCount,
-        });
-        counsel.counselContexts.markContextCompressed();
-        await this.counselsStore.update(counsel);
-
-        return compressedMessage;
-      })
-      .catch((error) => {
-        this.logger.error(`[MessageCompressor] compressContext failed: ${counsel.id.getString()}`, error);
+  public async compressContext(counsel: Counsels): Promise<void> {
+    try {
+      this.logger.log(`[MessageCompressor] compressContext: ${counsel.id.getString()}`);
+      const compressedMessageContent = await this.generateCompressedMessage(counsel);
+      const compressedMessage = await this.counselsStore.createCompressedMessage({
+        counselId: counsel.id,
+        content: compressedMessageContent,
+        messageCountAtCompression: counsel.messageCount,
       });
+      counsel.counselContexts.markContextCompressed();
+      await this.counselsStore.update(counsel);
+
+      this.logger.log(
+        `[MessageCompressor] Compressed message created: ${compressedMessage.id.getString()} for counsel: ${counsel.id.getString()}`,
+      );
+    } catch (error) {
+      this.logger.error(`[MessageCompressor] compressContext failed: ${counsel.id.getString()}`, error);
+      throw error;
+    }
   }
 
   private async generateCompressedMessage(counsel: Counsels): Promise<string> {

--- a/src/services/counselings/domains/counsels/models/counsel-compress-conditions.info.ts
+++ b/src/services/counselings/domains/counsels/models/counsel-compress-conditions.info.ts
@@ -1,0 +1,33 @@
+import { CounselCompressConditions } from "~counselings/domains/counsels/models/counsel-compress-conditions";
+
+import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { CounselCompressConditionId } from "~common/shared-kernel/identifiers/counsel-compress-condition.id";
+import { Dayjs } from "dayjs";
+
+export class CounselCompressConditionsInfo {
+  constructor(
+    public readonly id: CounselCompressConditionId,
+    public readonly counselId: CounselId,
+    public readonly messageCountAtLastCompression: number,
+    public readonly lastMessageCompressedAt: Dayjs | null,
+    public readonly createdAt: Dayjs,
+    public readonly updatedAt: Dayjs,
+    public readonly deletedAt: Dayjs | null,
+  ) {}
+
+  static fromDomain(counselCompressCondition: CounselCompressConditions): CounselCompressConditionsInfo {
+    return new CounselCompressConditionsInfo(
+      counselCompressCondition.id,
+      counselCompressCondition.counselId,
+      counselCompressCondition.messageCountAtLastCompression,
+      counselCompressCondition.lastMessageCompressedAt,
+      counselCompressCondition.createdAt,
+      counselCompressCondition.updatedAt,
+      counselCompressCondition.deletedAt,
+    );
+  }
+
+  static fromDomainArray(counselCompressConditionList: CounselCompressConditions[]): CounselCompressConditionsInfo[] {
+    return counselCompressConditionList.map((condition) => CounselCompressConditionsInfo.fromDomain(condition));
+  }
+}

--- a/src/services/counselings/domains/counsels/models/counsel-compress-conditions.ts
+++ b/src/services/counselings/domains/counsels/models/counsel-compress-conditions.ts
@@ -1,0 +1,105 @@
+import { getNowDayjs } from "~common/shared/utils/date";
+import { isDefined } from "~common/shared/utils/validate";
+import { DomainEntity } from "~common/shared-kernel/domains/domain-entity";
+import { Result } from "~common/shared-kernel/domains/results";
+import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
+import { CounselCompressConditionId } from "~common/shared-kernel/identifiers/counsel-compress-condition.id";
+import { Dayjs } from "dayjs";
+
+export interface CounselCompressConditionsNewProps {
+  counselId: CounselId;
+}
+
+export interface CounselCompressConditionsProps extends CounselCompressConditionsNewProps {
+  messageCountAtLastCompression: number;
+  lastMessageCompressedAt: Dayjs | null;
+  createdAt: Dayjs;
+  updatedAt: Dayjs;
+  deletedAt: Dayjs | null;
+}
+
+/**
+ * 상담 압축 조건 (Counsel Compress Conditions) 도메인 모델
+ * - 상담 세션의 메시지 압축 조건을 관리합니다.
+ * - 일정 메시지 수 이상이 쌓였을 때 압축 여부를 판단하는 로직을 포함합니다.
+ */
+export class CounselCompressConditions extends DomainEntity<
+  CounselCompressConditionsProps,
+  CounselCompressConditionId
+> {
+  public static readonly COMPRESSION_THRESHOLD = 20;
+
+  private constructor(props: CounselCompressConditionsProps, id: CounselCompressConditionId) {
+    super(props, id);
+  }
+
+  public static create(
+    props: CounselCompressConditionsProps,
+    id: CounselCompressConditionId,
+  ): Result<CounselCompressConditions> {
+    const counselCompressCondition = new CounselCompressConditions(props, id);
+    const result = counselCompressCondition.validateDomain();
+    if (result.isFailureResult()) {
+      return Result.fail(result.error);
+    }
+    return Result.ok<CounselCompressConditions>(counselCompressCondition);
+  }
+
+  public static createNew(newProps: CounselCompressConditionsNewProps): Result<CounselCompressConditions> {
+    const now = getNowDayjs();
+    const newId = new CounselCompressConditionId();
+    return this.create(
+      {
+        ...newProps,
+        messageCountAtLastCompression: 0,
+        lastMessageCompressedAt: null,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+      },
+      newId,
+    );
+  }
+  public validateDomain(): Result<void> {
+    if (this.props.messageCountAtLastCompression < 0) {
+      return Result.fail("[CounselCompressConditions] 마지막 압축 시점 메시지 카운트는 0 이상이어야 합니다");
+    }
+    if (!isDefined(this.props.counselId)) {
+      return Result.fail("[CounselCompressConditions] 상담 ID는 필수입니다");
+    }
+    return Result.ok();
+  }
+
+  public shouldCompressContext(currentMessageCount: number): boolean {
+    const nonCompressedCount = currentMessageCount - this.props.messageCountAtLastCompression;
+    return nonCompressedCount >= CounselCompressConditions.COMPRESSION_THRESHOLD;
+  }
+
+  public markContextCompressed(currentMessageCount: number): void {
+    const now = getNowDayjs();
+    this.props.messageCountAtLastCompression = currentMessageCount;
+    this.props.lastMessageCompressedAt = now;
+    this.props.updatedAt = now;
+  }
+
+  get messageCountAtLastCompression(): number {
+    return this.props.messageCountAtLastCompression;
+  }
+  get lastMessageCompressedAt(): Dayjs | null {
+    return this.props.lastMessageCompressedAt;
+  }
+
+  get counselId(): CounselId {
+    return this.props.counselId;
+  }
+
+  get createdAt(): Dayjs {
+    return this.props.createdAt;
+  }
+  get updatedAt(): Dayjs {
+    return this.props.updatedAt;
+  }
+  get deletedAt(): Dayjs | null {
+    return this.props.deletedAt;
+  }
+}

--- a/src/services/counselings/domains/counsels/models/counsel-contexts.info.ts
+++ b/src/services/counselings/domains/counsels/models/counsel-contexts.info.ts
@@ -16,15 +16,15 @@ import {
 
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
 import { CounselContextId } from "~common/shared-kernel/identifiers/counsel-context.id";
+import { CounselTechniqueId } from "~common/shared-kernel/identifiers/counsel-techinque.id";
 import { Dayjs } from "dayjs";
 
 export class CounselContextsInfo {
   constructor(
     public readonly id: CounselContextId,
     public readonly counselId: CounselId,
-    public readonly notCompressedMessageCount: number,
-    public readonly lastMessageCompressedAt: Dayjs | null,
-    public readonly currentTechniqueMessageCount: number,
+    public readonly counselTechniqueId: CounselTechniqueId,
+    public readonly messageCountAtLastTransition: number,
     public readonly impactDomain: ImpactDomain,
     public readonly timeframe: Timeframe,
     public readonly emotionPrimary: EmotionPrimary,
@@ -51,9 +51,8 @@ export class CounselContextsInfo {
     return new CounselContextsInfo(
       counselContexts.id,
       counselContexts.counselId,
-      counselContexts.notCompressedMessageCount,
-      counselContexts.lastMessageCompressedAt,
-      counselContexts.currentTechniqueMessageCount,
+      counselContexts.counselTechniqueId,
+      counselContexts.messageCountAtLastTransition,
       counselContexts.impactDomain,
       counselContexts.timeframe,
       counselContexts.emotionPrimary,

--- a/src/services/counselings/domains/counsels/models/counsel-contexts.ts
+++ b/src/services/counselings/domains/counsels/models/counsel-contexts.ts
@@ -19,16 +19,16 @@ import { DomainEntity } from "~common/shared-kernel/domains/domain-entity";
 import { Result } from "~common/shared-kernel/domains/results";
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
 import { CounselContextId } from "~common/shared-kernel/identifiers/counsel-context.id";
+import { CounselTechniqueId } from "~common/shared-kernel/identifiers/counsel-techinque.id";
 import { Dayjs } from "dayjs";
 
 export interface CounselContextsNewProps {
   counselId: CounselId;
+  counselTechniqueId: CounselTechniqueId;
 }
 
 export interface CounselContextsProps extends CounselContextsNewProps {
-  notCompressedMessageCount: number;
-  lastMessageCompressedAt: Dayjs | null;
-  currentTechniqueMessageCount: number;
+  messageCountAtLastTransition: number;
   impactDomain: ImpactDomain;
   timeframe: Timeframe;
   emotionPrimary: EmotionPrimary;
@@ -51,9 +51,12 @@ export interface CounselContextsProps extends CounselContextsNewProps {
   deletedAt: Dayjs | null;
 }
 
+/**
+ * 상담 맥락 (Counsel Contexts) 도메인 모델
+ * - 상담 세션의 맥락 정보를 관리합니다.
+ * - 기법 전이에 필요한 정보를 포함합니다.
+ */
 export class CounselContexts extends DomainEntity<CounselContextsProps, CounselContextId> {
-  public static readonly COMPRESSION_THRESHOLD = 20;
-
   private constructor(props: CounselContextsProps, id: CounselContextId) {
     super(props, id);
   }
@@ -73,9 +76,7 @@ export class CounselContexts extends DomainEntity<CounselContextsProps, CounselC
     return this.create(
       {
         ...newProps,
-        notCompressedMessageCount: 0,
-        lastMessageCompressedAt: null,
-        currentTechniqueMessageCount: 0,
+        messageCountAtLastTransition: 0,
         impactDomain: ImpactDomain.UNSPECIFIED,
         timeframe: Timeframe.UNSPECIFIED,
         emotionPrimary: EmotionPrimary.UNSPECIFIED,
@@ -101,8 +102,8 @@ export class CounselContexts extends DomainEntity<CounselContextsProps, CounselC
     );
   }
   public validateDomain(): Result<void> {
-    if (this.props.currentTechniqueMessageCount < 0) {
-      return Result.fail("[CounselContexts] 현 기법에서 누적 메시지 수는 0 이상이어야 합니다");
+    if (this.props.messageCountAtLastTransition < 0) {
+      return Result.fail("[CounselContexts] 마지막 기법 전이 시점 메시지 카운트는 0 이상이어야 합니다");
     }
     if (
       isDefined(this.props.emotionIntensity) &&
@@ -127,23 +128,10 @@ export class CounselContexts extends DomainEntity<CounselContextsProps, CounselC
     if (!isDefined(this.props.counselId)) {
       return Result.fail("[CounselContexts] 상담 ID는 필수입니다");
     }
+    if (!isDefined(this.props.counselTechniqueId)) {
+      return Result.fail("[CounselContexts] 상담 기법 ID는 필수입니다");
+    }
     return Result.ok();
-  }
-
-  public shouldCompressContext(): boolean {
-    return this.props.notCompressedMessageCount >= CounselContexts.COMPRESSION_THRESHOLD;
-  }
-
-  public markContextCompressed(): void {
-    const now = getNowDayjs();
-    this.props.notCompressedMessageCount = 0;
-    this.props.lastMessageCompressedAt = now;
-    this.props.updatedAt = now;
-  }
-
-  public increaseNotCompressedMessageCount(): void {
-    this.props.notCompressedMessageCount++;
-    this.props.updatedAt = getNowDayjs();
   }
 
   public applyUpdates(updates: Partial<CounselContextsProps>): void {
@@ -174,18 +162,21 @@ export class CounselContexts extends DomainEntity<CounselContextsProps, CounselC
     this.props.updatedAt = now;
   }
 
-  get notCompressedMessageCount(): number {
-    return this.props.notCompressedMessageCount;
-  }
-  get lastMessageCompressedAt(): Dayjs | null {
-    return this.props.lastMessageCompressedAt;
+  public updateCounselTechniqueId(counselTechniqueId: CounselTechniqueId, currentMessageCount: number): Result<void> {
+    this.props.counselTechniqueId = counselTechniqueId;
+    this.props.messageCountAtLastTransition = currentMessageCount;
+    this.props.updatedAt = getNowDayjs();
+    return Result.ok();
   }
 
   get counselId(): CounselId {
     return this.props.counselId;
   }
-  get currentTechniqueMessageCount(): number {
-    return this.props.currentTechniqueMessageCount;
+  get counselTechniqueId(): CounselTechniqueId {
+    return this.props.counselTechniqueId;
+  }
+  get messageCountAtLastTransition(): number {
+    return this.props.messageCountAtLastTransition;
   }
   get impactDomain(): ImpactDomain {
     return this.props.impactDomain;

--- a/src/services/counselings/domains/counsels/models/counsels.info.ts
+++ b/src/services/counselings/domains/counsels/models/counsels.info.ts
@@ -1,3 +1,4 @@
+import { CounselCompressConditionsInfo } from "~counselings/domains/counsels/models/counsel-compress-conditions.info";
 import { CounselContextsInfo } from "~counselings/domains/counsels/models/counsel-contexts.info";
 import { Counsels } from "~counselings/domains/counsels/models/counsels";
 
@@ -14,16 +15,11 @@ export class CounselsInfo {
     public readonly id: CounselId,
     public readonly userId: UserId,
     public readonly counselorId: CounselorId,
-    public readonly counselTechniqueId: CounselTechniqueId,
     public readonly promptVersionId: PromptVersionId,
     public readonly counselorUserRelationshipId: CounselorUserRelationshipId,
-    public readonly context: CounselContextsInfo,
     public readonly lastChatedAt: Dayjs | null,
     public readonly lastMessage: string | null,
     public readonly messageCount: number,
-    public readonly notCompressedMessageCount: number,
-    public readonly lastMessageCompressedAt: Dayjs | null,
-    public readonly shouldCompressContext: boolean,
     public readonly createdAt: Dayjs,
     public readonly updatedAt: Dayjs,
     public readonly deletedAt: Dayjs | null,
@@ -34,16 +30,11 @@ export class CounselsInfo {
       counsel.id,
       counsel.userId,
       counsel.counselorId,
-      counsel.counselTechniqueId,
       counsel.promptVersionId,
       counsel.counselorUserRelationshipId,
-      CounselContextsInfo.fromDomain(counsel.counselContexts),
       counsel.lastChatedAt,
       counsel.lastMessage,
       counsel.messageCount,
-      counsel.counselContexts.notCompressedMessageCount,
-      counsel.counselContexts.lastMessageCompressedAt,
-      counsel.counselContexts.shouldCompressContext(),
       counsel.createdAt,
       counsel.updatedAt,
       counsel.deletedAt,

--- a/src/services/counselings/domains/counsels/models/counsels.ts
+++ b/src/services/counselings/domains/counsels/models/counsels.ts
@@ -1,4 +1,3 @@
-import { CounselContexts } from "~counselings/domains/counsels/models/counsel-contexts";
 import { CounselCreatedPayloadSchema } from "~proto/com/hearlers/v1/message/counsel_pb";
 
 import { create } from "@bufbuild/protobuf";
@@ -8,7 +7,6 @@ import { AggregateRoot } from "~common/shared-kernel/domains/aggregate-root";
 import { Result } from "~common/shared-kernel/domains/results";
 import { CounselCreatedEvent } from "~common/shared-kernel/event/counsel-created.event";
 import { CounselId } from "~common/shared-kernel/identifiers/counsel.id";
-import { CounselTechniqueId } from "~common/shared-kernel/identifiers/counsel-techinque.id";
 import { CounselorId } from "~common/shared-kernel/identifiers/counselor.id";
 import { CounselorUserRelationshipId } from "~common/shared-kernel/identifiers/counselor-user-relationship.id";
 import { PromptVersionId } from "~common/shared-kernel/identifiers/prompt-version.id";
@@ -18,13 +16,11 @@ import { Dayjs } from "dayjs";
 export interface CounselsNewProps {
   userId: UserId;
   counselorId: CounselorId;
-  counselTechniqueId: CounselTechniqueId;
   promptVersionId: PromptVersionId;
   counselorUserRelationshipId: CounselorUserRelationshipId;
 }
 
 export interface CounselsProps extends CounselsNewProps {
-  counselContexts: CounselContexts;
   lastChatedAt: Dayjs | null;
   lastMessage: string | null;
 
@@ -35,6 +31,11 @@ export interface CounselsProps extends CounselsNewProps {
   deletedAt: Dayjs | null;
 }
 
+/**
+ * 상담 (Counsels) 도메인 모델
+ * - 상담 세션의 기본 정보를 관리합니다.
+ * - 상담사, 사용자, 프롬프트 버전 등의 연관 정보를 포함합니다.
+ */
 export class Counsels extends AggregateRoot<CounselsProps, CounselId> {
   private constructor(props: CounselsProps, id: CounselId) {
     super(props, id);
@@ -52,16 +53,9 @@ export class Counsels extends AggregateRoot<CounselsProps, CounselId> {
   public static createNew(newProps: CounselsNewProps): Result<Counsels> {
     const now = getNowDayjs();
     const newId = new CounselId();
-    const counselContexts = CounselContexts.createNew({
-      counselId: newId,
-    });
-    if (counselContexts.isFailureResult()) {
-      return Result.fail<Counsels>(counselContexts.error);
-    }
     const createdCounsel = this.create(
       {
         ...newProps,
-        counselContexts: counselContexts.value,
         lastChatedAt: null,
         lastMessage: null,
         messageCount: 0,
@@ -89,11 +83,6 @@ export class Counsels extends AggregateRoot<CounselsProps, CounselId> {
       return Result.fail("[Counsels] 상담사 ID는 필수입니다");
     }
 
-    // counselTechniqueId 검증
-    if (!isDefined(this.props.counselTechniqueId)) {
-      return Result.fail("[Counsels] 상담 기법 ID는 필수입니다");
-    }
-
     // promptVersionId 검증
     if (!isDefined(this.props.promptVersionId)) {
       return Result.fail("[Counsels] 프롬프트 버전 ID는 필수입니다");
@@ -102,10 +91,6 @@ export class Counsels extends AggregateRoot<CounselsProps, CounselId> {
     // counselorUserRelationshipId 검증
     if (!isDefined(this.props.counselorUserRelationshipId)) {
       return Result.fail("[Counsels] 상담사-사용자 관계 ID는 필수입니다");
-    }
-
-    if (!isDefined(this.props.counselContexts)) {
-      return Result.fail("[Counsels] 상담 컨텍스트는 필수입니다");
     }
 
     // messageCount 검증
@@ -136,10 +121,6 @@ export class Counsels extends AggregateRoot<CounselsProps, CounselId> {
     return this.props.userId;
   }
 
-  get counselTechniqueId(): CounselTechniqueId {
-    return this.props.counselTechniqueId;
-  }
-
   get promptVersionId(): PromptVersionId {
     return this.props.promptVersionId;
   }
@@ -158,10 +139,6 @@ export class Counsels extends AggregateRoot<CounselsProps, CounselId> {
 
   get messageCount(): number {
     return this.props.messageCount;
-  }
-
-  get counselContexts(): CounselContexts {
-    return this.props.counselContexts;
   }
 
   get createdAt(): Dayjs {
@@ -183,15 +160,8 @@ export class Counsels extends AggregateRoot<CounselsProps, CounselId> {
     return Result.ok();
   }
 
-  public updateCounselTechniqueId(counselTechniqueId: CounselTechniqueId): Result<void> {
-    this.props.counselTechniqueId = counselTechniqueId;
-    this.props.updatedAt = getNowDayjs();
-    return Result.ok();
-  }
-
   public increaseMessageCount(): void {
     this.props.messageCount++;
-    this.counselContexts.increaseNotCompressedMessageCount();
     this.props.updatedAt = getNowDayjs();
   }
 

--- a/src/services/counselings/presentations/grpc/counsels.mapper.ts
+++ b/src/services/counselings/presentations/grpc/counsels.mapper.ts
@@ -19,7 +19,8 @@ export class SchemaCounselsMapper {
       lastMessage: counsel.lastMessage ?? undefined,
       lastChatedAt: counsel.lastChatedAt ? counsel.lastChatedAt.toISOString() : undefined,
       promptVersionId: counsel.promptVersionId.getString(),
-      counselTechniqueId: counsel.counselTechniqueId.getString(),
+      // TODO - proto 수정 필요
+      counselTechniqueId: counsel.id.getString(),
       counselorUserRelationshipId: counsel.counselorUserRelationshipId.getString(),
       createdAt: counsel.createdAt.toISOString(),
       updatedAt: counsel.updatedAt.toISOString(),


### PR DESCRIPTION
## 상담 진행 Flow 개선 내역

### 문제 상황
- 기존 상담 진행 flow에서 **백그라운드 실행** 시 서로 다른 실행 흐름(트랜잭션)이 동시에 수행됨.
- 여러 흐름이 동일한 **counsel 객체**를 업데이트 → 나중에 수행된 커밋이 이전 커밋을 덮어씌우는 문제 발생  
  - 예: 메시지 전송 시 `message count`가 증가하지만, 이후 분석 단계에서 **분석 시작 시점의 count**로 덮어써버리는 상황

---

### 개선 사항

#### 1. 실행 흐름에 따른 도메인 분리
- **Main flow → Counsel 객체**
  - 상담 기본 정보 포함 (프롬프트 버전, 상담사, 사용자 아이디 등)
- **Compress flow → Counsel Compress Condition 객체**
  - 압축 로직에 필요한 정보 포함 (마지막 압축 시점 정보)
- **Analyze & Transition flow → Counsel Context 객체**
  - 분석 및 기법 전이에 필요한 정보 포함 (맥락 정보, 기법 아이디, 전환 시점 정보 등)

#### 2. Message Count 관리 방식 변경
- 메시지 생성 시 마다 `not compress message count`, `current technique message count`를 수정하면 다른 flow 데이터에 간섭 → 데이터 정합성 문제 발생
- 해결: **counsel 객체의 `message count`를 메인 지표**로 활용
  - 압축/전이 발생 시점의 `count` 값을 저장하는 방식으로 수정

#### 3. Fire-and-Forget 방식 제어
- 서비스 메서드에서 **fire-and-forget 여부**를 결정하지 않음
- 호출하는 쪽에서 결정할 수 있도록 **util 함수 제공**
- 분석 완료 후에야 context 데이터가 변화하고, 이때 기법 전이 파라미터가 바뀌므로  
  **분석 + 전이 로직을 합쳐 fire-and-forget 방식으로 수행**하도록 수정

#### 4. Lock Manager 도입
- 매 채팅마다 압축/분석 프로세스를 수행하는 것은 비효율적
- 각 상담별로 **동시에 하나의 프로세스만 수행**되도록 `lock manager` 추가
  - 초기 구현: 메모리 기반
  - 추후 분산환경 고려 시 수정 가능

---

analyze 로직만 보다가 점점 스케일이 커졌는데 확인부탁드립니다.
추가로 counsel technique id 를 counsel 객체가 아닌 context 객체에서 다루고 있어서 proto message 에도 수정이 필요할 것 같습니다. 머지하기 전에 해당 proto 확인 및 presentation mapper 수정 필요합니다.